### PR TITLE
Enable a field to be used for versioning

### DIFF
--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -159,6 +159,16 @@ class Field implements Buildable
     /**
      * @return Field
      */
+    public function useForVersioning()
+    {
+        $this->builder->isVersionField();
+
+        return $this;
+    }
+
+    /**
+     * @return Field
+     */
     public function build()
     {
         $this->builder->build();

--- a/tests/Builders/FieldTest.php
+++ b/tests/Builders/FieldTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Builders;
 
 use BadMethodCallException;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException;
 use LaravelDoctrine\Fluent\Builders\Field;
 use Tests\Stubs\Entities\StubEntity;
 
@@ -152,5 +154,136 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->field->nonExisting();
+    }
+
+    public function test_versioning_is_fluent()
+    {
+        $this->assertEquals($this->field, $this->field->useForVersioning());
+    }
+
+    public function test_integer_can_be_used_for_versioning()
+    {
+        $this->doTestValidTypeForVersioning("integer");
+    }
+
+    public function test_bigint_can_be_used_for_versioning()
+    {
+        $this->doTestValidTypeForVersioning("bigint");
+    }
+
+    public function test_smallint_can_be_used_for_versioning()
+    {
+        $this->doTestValidTypeForVersioning("smallint");
+    }
+
+    public function test_datetime_can_be_used_for_versioning()
+    {
+        $this->doTestValidTypeForVersioning("datetime");
+    }
+
+    public function test_array_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("array");
+    }
+
+    public function test_simple_array_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("simple_array");
+    }
+
+    public function test_json_array_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("json_array");
+    }
+
+    public function test_boolean_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("boolean");
+    }
+
+    public function test_datetimetz_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("datetimetz");
+    }
+
+    public function test_date_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("date");
+    }
+
+    public function test_time_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("time");
+    }
+
+    public function test_decimal_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("decimal");
+    }
+
+    public function test_object_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("object");
+    }
+
+    public function test_string_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("string");
+    }
+
+    public function test_text_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("text");
+    }
+
+    public function test_binary_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("binary");
+    }
+
+    public function test_blob_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("blob");
+    }
+
+    public function test_float_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("float");
+    }
+
+    public function test_guid_cannot_be_used_for_versioning()
+    {
+        $this->doTestInvalidTypeForVersioning("guid");
+    }
+
+    public function test_ids_cannot_be_used_for_versioning()
+    {
+        $this->setExpectedException(MappingException::class);
+
+        $this->field
+            ->primary()
+            ->useForVersioning()
+            ->build();
+    }
+
+    private function doTestValidTypeForVersioning($type)
+    {
+        $builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
+        $field = Field::make($builder, $type, "{$type}Field");
+
+        $field->useForVersioning()->build();
+
+        $cm = $builder->getClassMetadata();
+        $this->assertTrue($cm->isVersioned, "Field {$type}Field is not versioned.");
+        $this->assertEquals("{$type}Field", $cm->versionField);
+    }
+
+    private function doTestInvalidTypeForVersioning($type)
+    {
+        $builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
+        $field = Field::make($builder, $type, "aField");
+
+        $this->setExpectedException(MappingException::class);
+        $field->useForVersioning()->build();
     }
 }


### PR DESCRIPTION
## Usage

```
$builder->integer('someField')->useForVersioning();
// or...
$builder->bigint('someField')->useForVersioning();
// or...
$builder->smallint('someField')->useForVersioning();
// or...
$builder->datetime('someField')->useForVersioning();

// but not
$builder->integer('someField')->primary()->useForVersioning();
```
