### PR TITLE
Changes to multiple docblocks for a more precise type hinting

### DIFF
--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -20,7 +20,7 @@ class Builder extends AbstractBuilder implements Fluent
     use Fields, Relations, Macroable;
 
     /**
-     * @var array|Buildable[]
+     * @var Buildable[]
      */
     protected $queued = [];
 
@@ -176,7 +176,7 @@ class Builder extends AbstractBuilder implements Fluent
     }
 
     /**
-     * @return array|Buildable[]
+     * @return Buildable[]
      */
     public function getQueued()
     {
@@ -192,8 +192,8 @@ class Builder extends AbstractBuilder implements Fluent
     }
 
     /**
-     * @param $method
-     * @param $params
+     * @param string $method
+     * @param array  $params
      *
      * @return mixed
      */

--- a/src/Builders/Entity.php
+++ b/src/Builders/Entity.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 class Entity extends AbstractBuilder
 {
     /**
-     * @param $class
+     * @param string $class
      *
      * @return Entity
      */

--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -9,14 +9,32 @@ use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use LaravelDoctrine\Fluent\Buildable;
 
 /**
- * @method $this unique($flag = true)
- * @method $this nullable($flag = true)
- * @method $this length($length)
- * @method $this columnName($column)
- * @method $this precision($precision)
- * @method $this scale($scale)
- * @method $this default($default)
- * @method $this columnDefinition($def)
+ * @method $this unique(boolean $flag = true)   Boolean value to determine if the value of the column should be unique
+ *                                              across all rows of the underlying entities table.
+ *
+ * @method $this nullable(boolean $flag = true) Determines if NULL values are allowed for this column.
+ *
+ * @method $this length(int $length)            Used by the “string” type to determine its maximum length in the
+ *                                              database. Doctrine does not validate the length of string values
+ *                                              for you.
+ *
+ * @method $this columnName(string $column)     By default the property name is used for the database column name also,
+ *                                              however the ‘name’ attribute allows you to determine the column name.
+ *
+ * @method $this precision(int $precision)      The precision for a decimal (exact numeric) column (applies only for
+ *                                              decimal column), which is the maximum number of digits that are stored
+ *                                              for the values.
+ *
+ * @method $this scale(int $scale)              The scale for a decimal (exact numeric) column (applies only for
+ *                                              decimal column), which represents the number of digits to the right of
+ *                                              the decimal point and must not be greater than precision.
+ *
+ * @method $this default(string $default)       The default value to set for the column if no value is supplied.
+ * @method $this columnDefinition(string $def)  DDL SQL snippet that starts after the column name and specifies the
+ *                                              complete (non-portable!) column definition. This attribute allows to
+ *                                              make use of advanced RMDBS features. However you should make careful
+ *                                              use of this feature and the consequences. SchemaTool will not detect
+ *                                              changes on the column correctly anymore if you use “columnDefinition”.
  */
 class Field implements Buildable
 {
@@ -37,8 +55,8 @@ class Field implements Buildable
 
     /**
      * @param ClassMetadataBuilder $builder
-     * @param                      $type
-     * @param                      $name
+     * @param string               $type
+     * @param string               $name
      *
      * @throws \Doctrine\DBAL\DBALException
      * @return Field
@@ -55,7 +73,10 @@ class Field implements Buildable
     }
 
     /**
-     * @param $columnName
+     * By default the property name is used for the database column name also, however the ‘name’ attribute
+     * allows you to determine the column name.
+     *
+     * @param string $columnName
      *
      * @return $this
      */
@@ -89,6 +110,9 @@ class Field implements Buildable
     }
 
     /**
+     * Boolean value to determine if the column should be capable of representing only non-negative integers
+     * (applies only for integer column and might not be supported by all vendors).
+     *
      * @return Field
      */
     public function unsigned()
@@ -99,7 +123,9 @@ class Field implements Buildable
     }
 
     /**
-     * @param $default
+     * The default value to set for the column if no value is supplied.
+     *
+     * @param string $default
      *
      * @return Field
      */
@@ -111,7 +137,10 @@ class Field implements Buildable
     }
 
     /**
-     * @param $fixed
+     * Boolean value to determine if the specified length of a string column should be fixed or varying
+     * (applies only for string/binary column and might not be supported by all vendors).
+     *
+     * @param bool $fixed
      *
      * @return Field
      */
@@ -123,7 +152,9 @@ class Field implements Buildable
     }
 
     /**
-     * @param $comment
+     * The comment of the column in the schema (might not be supported by all vendors).
+     *
+     * @param string $comment
      *
      * @return Field
      */
@@ -135,7 +166,9 @@ class Field implements Buildable
     }
 
     /**
-     * @param $collation
+     * The collation of the column (only supported by Drizzle, Mysql, PostgreSQL>=9.1, Sqlite and SQLServer).
+     *
+     * @param string $collation
      *
      * @return Field
      */

--- a/src/Builders/Index.php
+++ b/src/Builders/Index.php
@@ -36,7 +36,7 @@ class Index implements Buildable
 
     /**
      * @param ClassMetadataBuilder $builder
-     * @param array                $columns
+     * @param string[]             $columns
      */
     public function __construct(ClassMetadataBuilder $builder, array $columns)
     {
@@ -68,7 +68,7 @@ class Index implements Buildable
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getColumns()
     {

--- a/src/Builders/Inheritance/InheritanceFactory.php
+++ b/src/Builders/Inheritance/InheritanceFactory.php
@@ -18,7 +18,7 @@ class InheritanceFactory
     ];
 
     /**
-     * @param                      $type
+     * @param string               $type
      * @param ClassMetadataBuilder $builder
      *
      * @return Inheritance

--- a/src/Builders/Traits/Fields.php
+++ b/src/Builders/Traits/Fields.php
@@ -11,9 +11,9 @@ use LogicException;
 trait Fields
 {
     /**
-     * @param string   $type
-     * @param string   $name
-     * @param callable $callback
+     * @param string        $type
+     * @param string        $name
+     * @param callable|null $callback
      *
      * @return Field
      */
@@ -72,8 +72,8 @@ trait Fields
     }
 
     /**
-     * @param string   $name
-     * @param callable $callback
+     * @param string        $name
+     * @param callable|null $callback
      *
      * @return Field
      */

--- a/src/Builders/Traits/Macroable.php
+++ b/src/Builders/Traits/Macroable.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 trait Macroable
 {
     /**
-     * @var array
+     * @var callable[]
      */
     protected static $macros = [];
 
@@ -37,7 +37,7 @@ trait Macroable
     /**
      * @param string $method
      *
-     * @return mixed
+     * @return callable
      */
     public function getMacro($method)
     {
@@ -45,8 +45,8 @@ trait Macroable
     }
 
     /**
-     * @param       $method
-     * @param array $params
+     * @param string $method
+     * @param array  $params
      *
      * @return mixed
      */

--- a/src/Builders/Traits/Relations.php
+++ b/src/Builders/Traits/Relations.php
@@ -46,8 +46,8 @@ trait Relations
     }
 
     /**
-     * @param               $field
-     * @param               $entity
+     * @param string        $field
+     * @param string        $entity
      * @param callable|null $callback
      *
      * @return ManyToOne
@@ -58,9 +58,9 @@ trait Relations
     }
 
     /**
-     * @param string   $field
-     * @param string   $entity
-     * @param callable $callback
+     * @param string        $field
+     * @param string        $entity
+     * @param callable|null $callback
      *
      * @return ManyToOne
      */
@@ -78,8 +78,8 @@ trait Relations
     }
 
     /**
-     * @param               $field
-     * @param               $entity
+     * @param string        $field
+     * @param string        $entity
      * @param callable|null $callback
      *
      * @return OneToMany
@@ -90,9 +90,9 @@ trait Relations
     }
 
     /**
-     * @param string   $field
-     * @param string   $entity
-     * @param callable $callback
+     * @param string        $field
+     * @param string        $entity
+     * @param callable|null $callback
      *
      * @return OneToMany
      */
@@ -110,8 +110,8 @@ trait Relations
     }
 
     /**
-     * @param               $field
-     * @param               $entity
+     * @param string        $field
+     * @param string        $entity
      * @param callable|null $callback
      *
      * @return ManyToMany
@@ -122,9 +122,9 @@ trait Relations
     }
 
     /**
-     * @param string   $field
-     * @param string   $entity
-     * @param callable $callback
+     * @param string        $field
+     * @param string        $entity
+     * @param callable|null $callback
      *
      * @return ManyToMany
      */
@@ -144,8 +144,8 @@ trait Relations
     /**
      * Adds a custom relation to the entity.
      *
-     * @param \LaravelDoctrine\Fluent\Relations\Relation $relation
-     * @param callable|null                              $callback
+     * @param Relation      $relation
+     * @param callable|null $callback
      *
      * @return Relation
      */

--- a/src/Fluent.php
+++ b/src/Fluent.php
@@ -47,16 +47,16 @@ interface Fluent
     public function unique($columns);
 
     /**
-     * @param          $type
-     * @param          $name
-     * @param callable $callback
+     * @param string        $type
+     * @param string        $name
+     * @param callable|null $callback
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
     public function field($type, $name, callable $callback = null);
 
     /**
-     * @param               $name
+     * @param string        $name
      * @param callable|null $callback
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
@@ -80,8 +80,8 @@ interface Fluent
     public function bigIncrements($name, callable $callback = null);
 
     /**
-     * @param          $name
-     * @param callable $callback
+     * @param string        $name
+     * @param callable|null $callback
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
@@ -258,8 +258,8 @@ interface Fluent
     public function oneToOne($field, $entity, callable $callback = null);
 
     /**
-     * @param               $field
-     * @param               $entity
+     * @param string        $field
+     * @param string        $entity
      * @param callable|null $callback
      *
      * @return ManyToOne
@@ -267,17 +267,17 @@ interface Fluent
     public function belongsTo($field, $entity, callable $callback = null);
 
     /**
-     * @param string   $field
-     * @param string   $entity
-     * @param callable $callback
+     * @param string        $field
+     * @param string        $entity
+     * @param callable|null $callback
      *
      * @return ManyToOne
      */
     public function manyToOne($field, $entity, callable $callback = null);
 
     /**
-     * @param               $field
-     * @param               $entity
+     * @param string        $field
+     * @param string        $entity
      * @param callable|null $callback
      *
      * @return OneToMany
@@ -285,17 +285,17 @@ interface Fluent
     public function hasMany($field, $entity, callable $callback = null);
 
     /**
-     * @param string   $field
-     * @param string   $entity
-     * @param callable $callback
+     * @param string        $field
+     * @param string        $entity
+     * @param callable|null $callback
      *
      * @return OneToMany
      */
     public function oneToMany($field, $entity, callable $callback = null);
 
     /**
-     * @param               $field
-     * @param               $entity
+     * @param string        $field
+     * @param string        $entity
      * @param callable|null $callback
      *
      * @return ManyToMany
@@ -303,9 +303,9 @@ interface Fluent
     public function belongsToMany($field, $entity, callable $callback = null);
 
     /**
-     * @param string   $field
-     * @param string   $entity
-     * @param callable $callback
+     * @param string        $field
+     * @param string        $entity
+     * @param callable|null $callback
      *
      * @return ManyToMany
      */
@@ -314,8 +314,8 @@ interface Fluent
     /**
      * Adds a custom relation to the entity.
      *
-     * @param \LaravelDoctrine\Fluent\Relations\Relation $relation
-     * @param callable|null                              $callback
+     * @param Relation      $relation
+     * @param callable|null $callback
      *
      * @return Relation
      */
@@ -338,7 +338,7 @@ interface Fluent
     public static function macro($method, callable $callback = null);
 
     /**
-     * @return array|Field[]
+     * @return Buildable[]
      */
     public function getQueued();
 

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -26,7 +26,7 @@ class FluentDriver implements MappingDriver
      * Initializes a new FileDriver that looks in the given path(s) for mapping
      * documents and operates in the specified operating mode.
      *
-     * @param array $mappings
+     * @param string[] $mappings
      */
     public function __construct(array $mappings = [])
     {
@@ -55,7 +55,7 @@ class FluentDriver implements MappingDriver
      * Gets the names of all mapped classes known to this driver.
      *
      * @throws MappingException
-     * @return array            The names of all mapped classes known to this driver.
+     * @return string[]         The names of all mapped classes known to this driver.
      */
     public function getAllClassNames()
     {
@@ -76,7 +76,7 @@ class FluentDriver implements MappingDriver
     }
 
     /**
-     * @param array $mappings
+     * @param string[] $mappings
      */
     public function addMappings(array $mappings = [])
     {

--- a/src/Mappers/MapperSet.php
+++ b/src/Mappers/MapperSet.php
@@ -26,7 +26,7 @@ class MapperSet
     }
 
     /**
-     * @param $className
+     * @param string $className
      *
      * @throws MappingException
      * @return Mapper
@@ -47,7 +47,7 @@ class MapperSet
     }
 
     /**
-     * @param $className
+     * @param string $className
      *
      * @return bool
      */
@@ -73,7 +73,7 @@ class MapperSet
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getClassNames()
     {

--- a/src/Relations/AbstractRelation.php
+++ b/src/Relations/AbstractRelation.php
@@ -73,7 +73,7 @@ abstract class AbstractRelation implements Relation
     abstract protected function createAssociation(ClassMetadataBuilder $builder, $relation, $entity);
 
     /**
-     * @param array $cascade
+     * @param string[] $cascade
      * @Enum({"persist", "remove", "merge", "detach", "refresh", "ALL"})
      *
      * @return $this
@@ -94,7 +94,7 @@ abstract class AbstractRelation implements Relation
     }
 
     /**
-     * @param $strategy
+     * @param string $strategy
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      *
      * @return $this

--- a/src/Relations/ManyToMany.php
+++ b/src/Relations/ManyToMany.php
@@ -4,6 +4,7 @@ namespace LaravelDoctrine\Fluent\Relations;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\Builder\ManyToManyAssociationBuilder;
+use Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder;
 use LaravelDoctrine\Fluent\Relations\Traits\Indexable;
 use LaravelDoctrine\Fluent\Relations\Traits\ManyTo;
 use LaravelDoctrine\Fluent\Relations\Traits\Orderable;

--- a/src/Relations/ManyToOne.php
+++ b/src/Relations/ManyToOne.php
@@ -51,7 +51,7 @@ class ManyToOne extends AbstractRelation
     }
 
     /**
-     * @param callable $callback
+     * @param callable|null $callback
      *
      * @return JoinColumn
      */
@@ -72,7 +72,7 @@ class ManyToOne extends AbstractRelation
      * @param string $method
      * @param array  $args
      *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      * @return $this
      */
     public function __call($method, $args)

--- a/src/Relations/Relation.php
+++ b/src/Relations/Relation.php
@@ -9,7 +9,7 @@ use LaravelDoctrine\Fluent\Buildable;
 interface Relation extends Buildable
 {
     /**
-     * @param array $cascade
+     * @param string[] $cascade
      * @Enum({"persist", "remove", "merge", "detach", "refresh", "ALL"})
      *
      * @return $this
@@ -17,7 +17,7 @@ interface Relation extends Buildable
     public function cascade(array $cascade);
 
     /**
-     * @param $strategy
+     * @param string $strategy
      * @Enum({"LAZY", "EAGER", "EXTRA_LAZY"})
      *
      * @return $this

--- a/src/Relations/Traits/ManyTo.php
+++ b/src/Relations/Traits/ManyTo.php
@@ -9,7 +9,7 @@ use LaravelDoctrine\Fluent\Relations\JoinColumn;
 trait ManyTo
 {
     /**
-     * @var array
+     * @var JoinColumn[]
      */
     protected $joinColumns = [];
 
@@ -73,7 +73,7 @@ trait ManyTo
     }
 
     /**
-     * @return array|JoinColumn[]
+     * @return JoinColumn[]
      */
     public function getJoinColumns()
     {

--- a/src/Relations/Traits/Orderable.php
+++ b/src/Relations/Traits/Orderable.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder;
 trait Orderable
 {
     /**
-     * @param        $name
+     * @param string $name
      * @param string $order
      *
      * @return $this


### PR DESCRIPTION
Added missing types, replaced some `array` with the actual `type[]` (mostly `string[]`)
