### PR TITLE
Allow full sequence generator configuration

### DIFF
--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -98,13 +98,25 @@ class Field implements Buildable
     }
 
     /**
-     * @param string $strategy
+     * @param string|callable $strategy
+     * @param callable|null   $callback
      *
      * @return Field
      */
-    public function generatedValue($strategy)
+    public function generatedValue($strategy, callable $callback = null)
     {
-        $this->builder->generatedValue($strategy);
+        if (is_callable($strategy)) {
+            $callback = $strategy;
+            $strategy = 'AUTO';
+        }
+
+        $generatedValue = new GeneratedValue($this->builder, $strategy);
+
+        if ($callback) {
+            $callback($generatedValue);
+        }
+
+        $generatedValue->build();
 
         return $this;
     }

--- a/src/Builders/GeneratedValue.php
+++ b/src/Builders/GeneratedValue.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace LaravelDoctrine\Fluent\Builders;
+
+use Doctrine\ORM\Mapping\Builder\FieldBuilder;
+use LaravelDoctrine\Fluent\Buildable;
+
+class GeneratedValue implements Buildable
+{
+    /**
+     * @var FieldBuilder
+     */
+    protected $builder;
+
+    /**
+     * @var string
+     */
+    protected $strategy;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var int
+     */
+    protected $initial = 1;
+
+    /**
+     * @var int
+     */
+    protected $size = 10;
+
+    /**
+     * @param FieldBuilder $builder
+     * @param string       $strategy
+     */
+    public function __construct(FieldBuilder $builder, $strategy = 'AUTO')
+    {
+        $this->builder  = $builder;
+        $this->strategy = $strategy;
+    }
+
+    /**
+     * @param string $strategy
+     *
+     * @return $this
+     */
+    public function strategy($strategy)
+    {
+        $this->strategy = $strategy;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function name($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param int $initial
+     *
+     * @return $this
+     */
+    public function initialValue($initial)
+    {
+        $this->initial = $initial;
+
+        return $this;
+    }
+
+    /**
+     * @param int $size
+     *
+     * @return $this
+     */
+    public function allocationSize($size)
+    {
+        $this->size = $size;
+
+        return $this;
+    }
+
+    /**
+     * Execute the build process
+     */
+    public function build()
+    {
+        $this->builder->generatedValue($this->strategy);
+
+        $this->builder->setSequenceGenerator(
+            $this->name ?: uniqid(),
+            $this->size,
+            $this->initial
+        );
+    }
+}

--- a/tests/Builders/GeneratedValueTest.php
+++ b/tests/Builders/GeneratedValueTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Builders;
+
+use Doctrine\ORM\Mapping\Builder\FieldBuilder;
+use LaravelDoctrine\Fluent\Builders\GeneratedValue;
+
+class GeneratedValueTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|FieldBuilder
+     */
+    protected $field;
+
+    /**
+     * @var GeneratedValue
+     */
+    protected $fluent;
+
+    protected function setUp()
+    {
+        $this->field = $this->getMockBuilder(FieldBuilder::class)->disableOriginalConstructor()->getMock();
+        $this->fluent = new GeneratedValue($this->field);
+    }
+    public function test_has_an_optional_strategy_that_defaults_to_auto()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+
+        $this->fluent->build();
+    }
+
+    public function test_strategy_can_be_overriden_on_construction()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+
+        (new GeneratedValue($this->field, 'SEQUENCE'))->build();
+    }
+
+    public function test_strategy_can_be_set_afterwards_as_well()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('IDENTITY');
+
+        $this->fluent->strategy('IDENTITY')->build();
+    }
+
+    public function test_can_change_the_sequence_name()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 10, 1
+        );
+
+        $this->fluent->name('crazy_name')->build();
+    }
+    public function test_can_change_the_sequence_name_and_alloc_size()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 42, 1
+        );
+
+        $this->fluent
+            ->name('crazy_name')
+            ->allocationSize(42)
+            ->build();
+    }
+    public function test_can_change_the_sequence_name_and_initial_value()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 10, 23
+        );
+
+        $this->fluent
+            ->name('crazy_name')
+            ->initialValue(23)
+            ->build();
+    }
+    public function test_can_change_the_sequence_name_alloc_size_and_initial_value()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 42, 23
+        );
+
+        $this->fluent
+            ->name('crazy_name')
+            ->allocationSize(42)
+            ->initialValue(23)
+            ->build();
+    }
+
+    public function test_changing_the_alloc_size_or_initial_value_without_setting_a_name_will_generate_a_random_name()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            $this->anything(), 42, 23
+        );
+
+        $this->fluent
+            ->allocationSize(42)
+            ->initialValue(23)
+            ->build();
+    }
+
+
+}


### PR DESCRIPTION
All sequence generator configuration is done through a callback, to allow the Field to return itself rather than breaking the fluent interface.
