### PR TITLE
Allow tables with custom schemas

### DIFF
--- a/src/Builders/Table.php
+++ b/src/Builders/Table.php
@@ -15,4 +15,16 @@ class Table extends AbstractBuilder
 
         return $this;
     }
+
+    /**
+     * @param string $schema
+     *
+     * @return $this
+     */
+    public function schema($schema)
+    {
+        $this->builder->getClassMetadata()->setPrimaryTable(['schema' => $schema]);
+
+        return $this;
+    }
 }

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -31,4 +31,18 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('users', $this->builder->getClassMetadata()->getTableName());
     }
+
+    public function test_detects_schema_from_names()
+    {
+        $this->table->setName('some_schema.users');
+
+        $this->assertEquals('some_schema', $this->builder->getClassMetadata()->getSchemaName());
+    }
+
+    public function test_can_change_only_the_schema()
+    {
+        $this->table->schema('a_schema');
+
+        $this->assertEquals('a_schema', $this->builder->getClassMetadata()->getSchemaName());
+    }
 }


### PR DESCRIPTION
## Usage

```
$builder->table('foo')->schema('bar');
// or
$builder->table('bar.foo')
// or 
$builder->table(function(Table $table){
    $table->setName('foo')->schema('bar');
});
```
