### PR TITLE
bugfix: sequences cannot start with a number.

### DIFF
--- a/src/Builders/GeneratedValue.php
+++ b/src/Builders/GeneratedValue.php
@@ -98,7 +98,7 @@ class GeneratedValue implements Buildable
         $this->builder->generatedValue($this->strategy);
 
         $this->builder->setSequenceGenerator(
-            $this->name ?: uniqid(),
+            $this->name ?: uniqid('seq_'),
             $this->size,
             $this->initial
         );

--- a/tests/Builders/GeneratedValueTest.php
+++ b/tests/Builders/GeneratedValueTest.php
@@ -103,5 +103,13 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
             ->build();
     }
 
+    public function test_the_random_name_cannot_start_with_a_number()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            $this->matchesRegularExpression('/^[^0-9]/'), 10, 1
+        );
 
+        $this->fluent->build();
+    }
 }


### PR DESCRIPTION
Random name generator for sequences was generating strings that could start with a number.
