### PR TITLE
Revisited generated values and added custom generators

### DIFF
--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Buildable;
 
 /**
@@ -44,13 +45,20 @@ class Field implements Buildable
     protected $builder;
 
     /**
+     * @var ClassMetadataInfo
+     */
+    protected $classMetadata;
+
+    /**
      * Protected constructor to force usage of factory method
      *
-     * @param FieldBuilder $builder
+     * @param FieldBuilder      $builder
+     * @param ClassMetadataInfo $classMetadata
      */
-    protected function __construct(FieldBuilder $builder)
+    protected function __construct(FieldBuilder $builder, ClassMetadataInfo $classMetadata)
     {
-        $this->builder = $builder;
+        $this->builder       = $builder;
+        $this->classMetadata = $classMetadata;
     }
 
     /**
@@ -67,9 +75,7 @@ class Field implements Buildable
 
         $field = $builder->createField($name, $type->getName());
 
-        return new static(
-            $field
-        );
+        return new static($field, $builder->getClassMetadata());
     }
 
     /**
@@ -92,25 +98,19 @@ class Field implements Buildable
      */
     public function autoIncrement()
     {
-        $this->generatedValue('AUTO');
+        $this->generatedValue();
 
         return $this;
     }
 
     /**
-     * @param string|callable $strategy
-     * @param callable|null   $callback
+     * @param callable|null $callback
      *
      * @return Field
      */
-    public function generatedValue($strategy, callable $callback = null)
+    public function generatedValue(callable $callback = null)
     {
-        if (is_callable($strategy)) {
-            $callback = $strategy;
-            $strategy = 'AUTO';
-        }
-
-        $generatedValue = new GeneratedValue($this->builder, $strategy);
+        $generatedValue = new GeneratedValue($this->builder, $this->classMetadata);
 
         if ($callback) {
             $callback($generatedValue);

--- a/src/Builders/GeneratedValue.php
+++ b/src/Builders/GeneratedValue.php
@@ -3,6 +3,7 @@
 namespace LaravelDoctrine\Fluent\Builders;
 
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Buildable;
 
 class GeneratedValue implements Buildable
@@ -15,7 +16,7 @@ class GeneratedValue implements Buildable
     /**
      * @var string
      */
-    protected $strategy;
+    protected $strategy = 'AUTO';
 
     /**
      * @var string
@@ -33,61 +34,129 @@ class GeneratedValue implements Buildable
     protected $size = 10;
 
     /**
-     * @param FieldBuilder $builder
-     * @param string       $strategy
+     * @var string
      */
-    public function __construct(FieldBuilder $builder, $strategy = 'AUTO')
+    protected $generator;
+
+    /**
+     * @var ClassMetadataInfo
+     */
+    protected $classMetadata;
+
+    /**
+     * @param FieldBuilder      $builder
+     * @param ClassMetadataInfo $classMetadata
+     */
+    public function __construct(FieldBuilder $builder, ClassMetadataInfo $classMetadata)
     {
-        $this->builder  = $builder;
-        $this->strategy = $strategy;
+        $this->builder       = $builder;
+        $this->classMetadata = $classMetadata;
     }
 
     /**
-     * @param string $strategy
+     * Tells Doctrine to pick the strategy that is preferred by the used database platform. The preferred strategies
+     * are IDENTITY for MySQL, SQLite, MsSQL and SQL Anywhere and SEQUENCE for Oracle and PostgreSQL. This strategy
+     * provides full portability.
+     *
+     * @param string|null $name
+     * @param string|null $initial
+     * @param string|null $size
      *
      * @return $this
      */
-    public function strategy($strategy)
+    public function auto($name = null, $initial = null, $size = null)
     {
-        $this->strategy = $strategy;
+        $this->strategy = 'AUTO';
+        $this->customize($name, $initial, $size);
 
         return $this;
     }
 
     /**
-     * @param string $name
+     * Tells Doctrine to use a database sequence for ID generation. This strategy does currently not provide full
+     * portability. Sequences are supported by Oracle, PostgreSql and SQL Anywhere.
+     *
+     * @param string|null $name
+     * @param string|null $initial
+     * @param string|null $size
      *
      * @return $this
      */
-    public function name($name)
+    public function sequence($name = null, $initial = null, $size = null)
     {
-        $this->name = $name;
+        $this->strategy = 'SEQUENCE';
+        $this->customize($name, $initial, $size);
 
         return $this;
     }
 
     /**
-     * @param int $initial
+     * Tells Doctrine to use special identity columns in the database that generate a value on insertion of a row.
+     * This strategy does currently not provide full portability and is supported by the following platforms:
+     * MySQL/SQLite/SQL Anywhere (AUTO_INCREMENT), MSSQL (IDENTITY) and PostgreSQL (SERIAL).
      *
      * @return $this
      */
-    public function initialValue($initial)
+    public function identity()
     {
-        $this->initial = $initial;
+        $this->strategy = 'IDENTITY';
 
         return $this;
     }
 
     /**
-     * @param int $size
+     * Tells Doctrine to use the built-in Universally Unique Identifier generator.
+     * This strategy provides full portability.
      *
      * @return $this
      */
-    public function allocationSize($size)
+    public function uuid()
     {
-        $this->size = $size;
+        $this->strategy = 'UUID';
 
         return $this;
+    }
+
+    /**
+     * Tells Doctrine that the identifiers are assigned (and thus generated) by your code. The assignment must take
+     * place before a new entity is passed to EntityManager#persist.
+     * NONE is the same as leaving off the @GeneratedValue entirely.
+     *
+     * @return $this
+     */
+    public function none()
+    {
+        $this->strategy = 'NONE';
+
+        return $this;
+    }
+
+    /**
+     * Tells Doctrine to use a custom Generator class to generate identifiers.
+     * The given class must extend \Doctrine\ORM\Id\AbstractIdGenerator
+     *
+     * @param string $generatorClass
+     *
+     * @return $this
+     */
+    public function custom($generatorClass)
+    {
+        $this->strategy  = 'CUSTOM';
+        $this->generator = $generatorClass;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $name
+     * @param string|null $initial
+     * @param string|null $size
+     */
+    private function customize($name, $initial, $size)
+    {
+        $this->name    = $name    ?: $this->name;
+        $this->initial = $initial ?: $this->initial;
+        $this->size    = $size    ?: $this->size;
     }
 
     /**
@@ -97,10 +166,12 @@ class GeneratedValue implements Buildable
     {
         $this->builder->generatedValue($this->strategy);
 
-        $this->builder->setSequenceGenerator(
-            $this->name ?: uniqid(),
-            $this->size,
-            $this->initial
-        );
+        if ($this->name) {
+            $this->builder->setSequenceGenerator($this->name, $this->size, $this->initial);
+        }
+
+        if ($this->generator) {
+            $this->classMetadata->setCustomGeneratorDefinition(['class' => $this->generator]);
+        }
     }
 }

--- a/tests/Builders/FieldTest.php
+++ b/tests/Builders/FieldTest.php
@@ -73,21 +73,19 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_set_generated_value_strategy()
     {
-        $this->field->generatedValue('UUID');
+        $this->field->generatedValue();
 
         $this->field->build();
 
-        $this->assertTrue($this->builder->getClassMetadata()->isIdentifierUuid());
+        $this->assertTrue($this->builder->getClassMetadata()->generatorType == ClassMetadataInfo::GENERATOR_TYPE_AUTO);
     }
 
     public function test_can_enrich_generated_value_with_a_closure()
     {
         $field = Field::make($this->builder, 'integer', 'gen');
 
-        $field->generatedValue('SEQUENCE', function(GeneratedValue $builder){
-            $builder->name('sequence_name');
-            $builder->initialValue(4);
-            $builder->allocationSize(15);
+        $field->generatedValue(function(GeneratedValue $builder){
+            $builder->sequence('sequence_name', 4, 15);
         });
 
         $field->build();
@@ -104,18 +102,14 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $field = Field::make($this->builder, 'integer', 'gen');
 
         $field->generatedValue(function(GeneratedValue $builder){
-            $builder->strategy('IDENTITY')->name('a_seq_name');
+            $builder->identity();
         });
 
         $field->build();
 
         $this->assertTrue($this->builder->getClassMetadata()->isIdGeneratorIdentity());
 
-        $this->assertEquals([
-            'sequenceName' => 'a_seq_name',
-            'initialValue' => 1,
-            'allocationSize' => 10,
-        ], $this->builder->getClassMetadata()->sequenceGeneratorDefinition);
+        $this->assertNull($this->builder->getClassMetadata()->sequenceGeneratorDefinition);
     }
 
     public function test_can_make_field_unsigned()

--- a/tests/Builders/GeneratedValueTest.php
+++ b/tests/Builders/GeneratedValueTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Builders;
 
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\GeneratedValue;
 
 class GeneratedValueTest extends \PHPUnit_Framework_TestCase
@@ -13,6 +14,11 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
     protected $field;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ClassMetadataInfo
+     */
+    protected $cm;
+
+    /**
      * @var GeneratedValue
      */
     protected $fluent;
@@ -20,8 +26,11 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->field = $this->getMockBuilder(FieldBuilder::class)->disableOriginalConstructor()->getMock();
-        $this->fluent = new GeneratedValue($this->field);
+        $this->cm    = $this->getMockBuilder(ClassMetadataInfo::class)->disableOriginalConstructor()->getMock();
+
+        $this->fluent = new GeneratedValue($this->field, $this->cm);
     }
+
     public function test_has_an_optional_strategy_that_defaults_to_auto()
     {
         $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
@@ -29,79 +38,153 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
         $this->fluent->build();
     }
 
-    public function test_strategy_can_be_overriden_on_construction()
+    public function test_auto_strategy_can_be_set_afterwards_as_well()
     {
-        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
 
-        (new GeneratedValue($this->field, 'SEQUENCE'))->build();
+        $this->fluent->auto()->build();
     }
 
-    public function test_strategy_can_be_set_afterwards_as_well()
+    public function test_identity_strategy_can_be_set_afterwards()
     {
         $this->field->expects($this->once())->method('generatedValue')->with('IDENTITY');
 
-        $this->fluent->strategy('IDENTITY')->build();
+        $this->fluent->identity()->build();
     }
 
-    public function test_can_change_the_sequence_name()
+    public function test_uuid_strategy_can_be_set_afterwards()
     {
-        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
-        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
-            'crazy_name', 10, 1
+        $this->field->expects($this->once())->method('generatedValue')->with('UUID');
+
+        $this->fluent->uuid()->build();
+    }
+
+    public function test_none_strategy_can_be_set_afterwards()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('NONE');
+
+        $this->fluent->none()->build();
+    }
+
+    public function test_a_custom_strategy_with_the_implementation_can_be_set_afterwards()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('CUSTOM');
+        $this->cm->expects($this->once())->method('setCustomGeneratorDefinition')->with(
+            ['class' => 'A\\Class\\Implementing\\AbstractIdGenerator']
         );
 
-        $this->fluent->name('crazy_name')->build();
+        $this->fluent->custom('A\\Class\\Implementing\\AbstractIdGenerator')->build();
     }
-    public function test_can_change_the_sequence_name_and_alloc_size()
+
+    public function test_can_change_the_sequence_name_on_auto_strategy()
     {
         $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
         $this->field->expects($this->once())->method('setSequenceGenerator')->with(
-            'crazy_name', 42, 1
+            'crazy_name', $this->anything(), $this->anything()
         );
 
-        $this->fluent
-            ->name('crazy_name')
-            ->allocationSize(42)
-            ->build();
+        $this->fluent->auto('crazy_name')->build();
     }
-    public function test_can_change_the_sequence_name_and_initial_value()
+
+    public function test_can_change_the_sequence_name_and_alloc_size_on_auto_strategy()
     {
         $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
         $this->field->expects($this->once())->method('setSequenceGenerator')->with(
-            'crazy_name', 10, 23
-        );
-
-        $this->fluent
-            ->name('crazy_name')
-            ->initialValue(23)
-            ->build();
-    }
-    public function test_can_change_the_sequence_name_alloc_size_and_initial_value()
-    {
-        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
-        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
-            'crazy_name', 42, 23
-        );
-
-        $this->fluent
-            ->name('crazy_name')
-            ->allocationSize(42)
-            ->initialValue(23)
-            ->build();
-    }
-
-    public function test_changing_the_alloc_size_or_initial_value_without_setting_a_name_will_generate_a_random_name()
-    {
-        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
-        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
-            $this->anything(), 42, 23
+            'crazy_name', $this->anything(), 42
         );
 
         $this->fluent
-            ->allocationSize(42)
-            ->initialValue(23)
+            ->auto('crazy_name', 42)
             ->build();
     }
 
+    public function test_can_change_the_sequence_name_and_initial_value_on_auto_strategy()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 23, $this->anything()
+        );
 
+        $this->fluent
+            ->auto('crazy_name', null, 23)
+            ->build();
+    }
+
+    public function test_can_change_the_sequence_name_alloc_size_and_initial_value_on_auto_strategy()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 23, 42
+        );
+
+        $this->fluent
+            ->auto('crazy_name', 42, 23)
+            ->build();
+    }
+
+    public function test_changing_the_alloc_size_or_initial_value_in_auto_without_setting_a_name_will_get_ignored()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('AUTO');
+        $this->field->expects($this->never())->method('setSequenceGenerator');
+
+        $this->fluent
+            ->auto(null, 42, 23)
+            ->build();
+    }
+
+    public function test_can_change_the_sequence_name_on_sequence_strategy()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', $this->anything(), $this->anything()
+        );
+
+        $this->fluent->sequence('crazy_name')->build();
+    }
+
+    public function test_can_change_the_sequence_name_and_alloc_size_on_sequence_strategy()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', $this->anything(), 42
+        );
+
+        $this->fluent
+            ->sequence('crazy_name', 42)
+            ->build();
+    }
+
+    public function test_can_change_the_sequence_name_and_initial_value_on_sequence_strategy()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 23, $this->anything()
+        );
+
+        $this->fluent
+            ->sequence('crazy_name', null, 23)
+            ->build();
+    }
+
+    public function test_can_change_the_sequence_name_alloc_size_and_initial_value_on_sequence_strategy()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+        $this->field->expects($this->once())->method('setSequenceGenerator')->with(
+            'crazy_name', 23, 42
+        );
+
+        $this->fluent
+            ->sequence('crazy_name', 42, 23)
+            ->build();
+    }
+
+    public function test_changing_the_alloc_size_or_initial_value_in_sequence_without_setting_a_name_will_get_ignored()
+    {
+        $this->field->expects($this->once())->method('generatedValue')->with('SEQUENCE');
+        $this->field->expects($this->never())->method('setSequenceGenerator');
+
+        $this->fluent
+            ->sequence(null, 42, 23)
+            ->build();
+    }
 }


### PR DESCRIPTION
For now, the Field builder will have to have access to ClassMetadataInfo, as Doctrine's FieldBuilder is missing a customIdGenerator setter: https://github.com/doctrine/doctrine2/pull/1518
