### PR TITLE
Guess relations and embeded names

### DIFF
--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -149,17 +149,17 @@ class Builder extends AbstractBuilder implements Fluent
 
     /**
      * @param string        $embeddable
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return Embedded
      */
-    public function embed($embeddable, $field, callable $callback = null)
+    public function embed($embeddable, $field = null, callable $callback = null)
     {
         $embedded = new Embedded(
             $this->builder,
             $this->namingStrategy,
-            $field,
+            $this->guessSingularField($embeddable, $field),
             $embeddable
         );
 

--- a/src/Builders/Traits/Relations.php
+++ b/src/Builders/Traits/Relations.php
@@ -2,6 +2,7 @@
 
 namespace LaravelDoctrine\Fluent\Builders\Traits;
 
+use Illuminate\Support\Str;
 use LaravelDoctrine\Fluent\Buildable;
 use LaravelDoctrine\Fluent\Relations\ManyToMany;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
@@ -13,30 +14,30 @@ trait Relations
 {
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return OneToOne
      */
-    public function hasOne($entity, $field, callable $callback = null)
+    public function hasOne($entity, $field = null, callable $callback = null)
     {
         return $this->oneToOne($entity, $field, $callback);
     }
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return OneToOne
      */
-    public function oneToOne($entity, $field, callable $callback = null)
+    public function oneToOne($entity, $field = null, callable $callback = null)
     {
         return $this->addRelation(
             new OneToOne(
                 $this->getBuilder(),
                 $this->getNamingStrategy(),
-                $field,
+                $this->guessSingularField($entity, $field),
                 $entity
             ),
             $callback
@@ -45,30 +46,30 @@ trait Relations
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return ManyToOne
      */
-    public function belongsTo($entity, $field, callable $callback = null)
+    public function belongsTo($entity, $field = null, callable $callback = null)
     {
         return $this->manyToOne($entity, $field, $callback);
     }
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return ManyToOne
      */
-    public function manyToOne($entity, $field, callable $callback = null)
+    public function manyToOne($entity, $field = null, callable $callback = null)
     {
         return $this->addRelation(
             new ManyToOne(
                 $this->getBuilder(),
                 $this->getNamingStrategy(),
-                $field,
+                $this->guessSingularField($entity, $field),
                 $entity
             ),
             $callback
@@ -77,30 +78,30 @@ trait Relations
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return OneToMany
      */
-    public function hasMany($entity, $field, callable $callback = null)
+    public function hasMany($entity, $field = null, callable $callback = null)
     {
         return $this->oneToMany($entity, $field, $callback);
     }
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return OneToMany
      */
-    public function oneToMany($entity, $field, callable $callback = null)
+    public function oneToMany($entity, $field = null, callable $callback = null)
     {
         return $this->addRelation(
             new OneToMany(
                 $this->getBuilder(),
                 $this->getNamingStrategy(),
-                $field,
+                $this->guessPluralField($entity, $field),
                 $entity
             ),
             $callback
@@ -109,30 +110,30 @@ trait Relations
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return ManyToMany
      */
-    public function belongsToMany($entity, $field, callable $callback = null)
+    public function belongsToMany($entity, $field = null, callable $callback = null)
     {
         return $this->manyToMany($entity, $field, $callback);
     }
 
     /**
      * @param string        $entity
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return ManyToMany
      */
-    public function manyToMany($entity, $field, callable $callback = null)
+    public function manyToMany($entity, $field = null, callable $callback = null)
     {
         return $this->addRelation(
             new ManyToMany(
                 $this->getBuilder(),
                 $this->getNamingStrategy(),
-                $field,
+                $this->guessPluralField($entity, $field),
                 $entity
             ),
             $callback
@@ -152,6 +153,28 @@ trait Relations
         $this->callbackAndQueue($relation, $callback);
 
         return $relation;
+    }
+
+    /**
+     * @param string      $entity
+     * @param string|null $field
+     *
+     * @return string
+     */
+    protected function guessSingularField($entity, $field = null)
+    {
+        return $field ?: Str::camel(class_basename($entity));
+    }
+
+    /**
+     * @param string      $entity
+     * @param string|null $field
+     *
+     * @return string
+     */
+    protected function guessPluralField($entity, $field = null)
+    {
+        return $field ?: Str::plural($this->guessSingularField($entity));
     }
 
     /**

--- a/src/Fluent.php
+++ b/src/Fluent.php
@@ -246,7 +246,7 @@ interface Fluent
      *
      * @return OneToOne
      */
-    public function hasOne($entity, $field, callable $callback = null);
+    public function hasOne($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -255,7 +255,7 @@ interface Fluent
      *
      * @return OneToOne
      */
-    public function oneToOne($entity, $field, callable $callback = null);
+    public function oneToOne($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -264,7 +264,7 @@ interface Fluent
      *
      * @return ManyToOne
      */
-    public function belongsTo($entity, $field, callable $callback = null);
+    public function belongsTo($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -273,7 +273,7 @@ interface Fluent
      *
      * @return ManyToOne
      */
-    public function manyToOne($entity, $field, callable $callback = null);
+    public function manyToOne($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -282,7 +282,7 @@ interface Fluent
      *
      * @return OneToMany
      */
-    public function hasMany($entity, $field, callable $callback = null);
+    public function hasMany($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -291,7 +291,7 @@ interface Fluent
      *
      * @return OneToMany
      */
-    public function oneToMany($entity, $field, callable $callback = null);
+    public function oneToMany($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -300,7 +300,7 @@ interface Fluent
      *
      * @return ManyToMany
      */
-    public function belongsToMany($entity, $field, callable $callback = null);
+    public function belongsToMany($entity, $field = null, callable $callback = null);
 
     /**
      * @param string        $entity
@@ -384,12 +384,12 @@ interface Fluent
 
     /**
      * @param string        $embeddable
-     * @param string        $field
+     * @param string|null   $field
      * @param callable|null $callback
      *
      * @return Embedded
      */
-    public function embed($embeddable, $field, callable $callback = null);
+    public function embed($embeddable, $field = null, callable $callback = null);
 
     /**
      * @param string        $type

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\ORM\Mapping\MappingException;
 use InvalidArgumentException;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Builders\Embedded;
@@ -724,9 +725,128 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('custom_table_name', $this->fluent->getClassMetadata()->getAssociationMapping('manyToMany')['joinTable']['name']);
         $this->assertEquals('source_id', $this->fluent->getClassMetadata()->getAssociationMapping('manyToMany')['joinTable']['joinColumns'][0]['name']);
     }
+
+    public function test_can_guess_a_one_to_one_relation_name()
+    {
+        $this->fluent->oneToOne(FluentEntity::class);
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntity');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the oneToOne relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_a_has_one_relation_name()
+    {
+        $this->fluent->hasOne(FluentEntity::class);
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntity');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the hasOne relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_a_belongs_to_relation_name()
+    {
+        $this->fluent->belongsTo(FluentEntity::class);
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntity');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the belongsTo relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_a_one_to_many_relation_name()
+    {
+        $this->fluent->oneToMany(FluentEntity::class)->mappedBy('fluentEntity');
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntities');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the oneToMany relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_a_has_many_relation_name()
+    {
+        $this->fluent->hasMany(FluentEntity::class)->mappedBy('fluentEntity');
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntities');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the hasMany relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_a_many_to_many_relation_name()
+    {
+        $this->fluent->manyToMany(FluentEntity::class);
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntities');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the manyToMany relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_a_belongs_to_many_relation_name()
+    {
+        $this->fluent->belongsToMany(FluentEntity::class);
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        try {
+            $this->fluent->getClassMetadata()->getAssociationMapping('fluentEntities');
+        } catch (MappingException $e) {
+            $this->fail("Could not find default name for the belongsToMany relation. " . $e->getMessage());
+        }
+    }
+
+    public function test_can_guess_an_embeded_field_name()
+    {
+        $this->fluent->embed(StubEmbeddable::class);
+
+        foreach ($this->fluent->getQueued() as $field) {
+            $field->build();
+        }
+
+        $this->assertArrayHasKey(
+            'stubEmbeddable',
+            $this->fluent->getClassMetadata()->embeddedClasses
+        );
+    }
 }
 
 class FluentEntity
 {
-    protected $id, $name;
+    protected $id, $name, $fluentEntity, $fluentEntities;
 }


### PR DESCRIPTION
Based on the basename of the related class.
This makes the field name optional in relations and embeded classes.
