### PR TITLE
[BUGFIX] Unmapped classes should be considered transient

### DIFF
--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -72,7 +72,9 @@ class FluentDriver implements MappingDriver
      */
     public function isTransient($className)
     {
-        return $this->mappers->getMapperFor($className)->isTransient();
+        return
+            ! $this->mappers->hasMapperFor($className) ||
+            $this->mappers->getMapperFor($className)->isTransient();
     }
 
     /**

--- a/tests/FluentDriverTest.php
+++ b/tests/FluentDriverTest.php
@@ -193,6 +193,13 @@ class FluentDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($driver->isTransient(StubMappedSuperClass::class));
     }
 
+    public function test_unmapped_classes_should_be_transient()
+    {
+        $driver = new FluentDriver;
+
+        $this->assertTrue($driver->isTransient(StubMappedSuperClass::class));
+    }
+
     public function test_it_should_fail_when_asked_for_metadata_that_was_not_added_to_it()
     {
         $driver = new FluentDriver();


### PR DESCRIPTION
This fails hard right now, and prevents entities from having an inheritance tree without being an inheritance mapping strategy.
