### PR TITLE
Pass the naming strategy along when creating an Entity object

### DIFF
--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -58,7 +58,7 @@ class Builder extends AbstractBuilder implements Fluent
             throw new LogicException();
         }
 
-        $entity = new Entity($this->builder);
+        $entity = new Entity($this->builder, $this->namingStrategy);
 
         if (is_callable($callback)) {
             $callback($entity);

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -172,6 +172,16 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(\LaravelDoctrine\Fluent\Builders\Entity::class, $entity);
     }
 
+    public function test_the_related_entity_builder_should_have_the_same_naming_strategy()
+    {
+        $entity = $this->fluent->entity();
+
+        $this->assertSame(
+            $this->fluent->getNamingStrategy(),
+            $entity->getNamingStrategy()
+        );
+    }
+
     public function test_can_set_inheritance()
     {
         $inheritance = $this->fluent->inheritance(Inheritance::SINGLE, function ($inheritance) {


### PR DESCRIPTION
I believe this is not needed right now, but as `Entity` inherits from `AbstractBuilder`, if a `NamingStrategy` is not given, it will create its own.

This change propagates the configured `NamingStrategy` with which the original `Builder` was given, to the internal `Entity` created.
