### PR TITLE
Allow both sides of a many-to-many relation to be configured as unique

### DIFF
--- a/src/Relations/ManyToMany.php
+++ b/src/Relations/ManyToMany.php
@@ -52,12 +52,13 @@ class ManyToMany extends AbstractRelation
     /**
      * @param string $joinColumn
      * @param string $references
+     * @param bool   $unique
      *
      * @return $this
      */
-    public function joinColumn($joinColumn, $references = 'id')
+    public function joinColumn($joinColumn, $references = 'id', $unique = false)
     {
-        $this->addJoinColumn(null, $joinColumn, $references, false);
+        $this->addJoinColumn(null, $joinColumn, $references, false, $unique);
 
         return $this;
     }
@@ -65,34 +66,37 @@ class ManyToMany extends AbstractRelation
     /**
      * @param string $foreignKey
      * @param string $references
+     * @param bool   $unique
      *
      * @return $this
      */
-    public function foreignKey($foreignKey, $references = 'id')
+    public function foreignKey($foreignKey, $references = 'id', $unique = false)
     {
-        return $this->joinColumn($foreignKey, $references);
+        return $this->joinColumn($foreignKey, $references, $unique);
     }
 
     /**
      * @param string $foreignKey
      * @param string $references
+     * @param bool   $unique
      *
      * @return $this
      */
-    public function source($foreignKey, $references = 'id')
+    public function source($foreignKey, $references = 'id', $unique = false)
     {
-        return $this->joinColumn($foreignKey, $references);
+        return $this->joinColumn($foreignKey, $references, $unique);
     }
 
     /**
      * @param string $inverseKey
      * @param string $references
+     * @param bool   $unique
      *
      * @return $this
      */
-    public function inverseKey($inverseKey, $references = 'id')
+    public function inverseKey($inverseKey, $references = 'id', $unique = false)
     {
-        $this->association->addInverseJoinColumn($inverseKey, $references, false);
+        $this->association->addInverseJoinColumn($inverseKey, $references, false, $unique);
 
         return $this;
     }
@@ -100,11 +104,12 @@ class ManyToMany extends AbstractRelation
     /**
      * @param string $inverseKey
      * @param string $references
+     * @param bool   $unique
      *
      * @return $this
      */
-    public function target($inverseKey, $references = 'id')
+    public function target($inverseKey, $references = 'id', $unique = false)
     {
-        return $this->inverseKey($inverseKey, $references);
+        return $this->inverseKey($inverseKey, $references, $unique);
     }
 }

--- a/tests/Relations/ManyToManyTest.php
+++ b/tests/Relations/ManyToManyTest.php
@@ -60,6 +60,20 @@ class ManyToManyTest extends RelationTestCase
         $this->assertEquals('other_reference',
             $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['referencedColumnName']);
         $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['nullable']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['unique']);
+    }
+
+    public function test_can_set_unique_join_column()
+    {
+        $this->relation->joinColumn('join_column', 'other_reference', true);
+
+        $this->relation->build();
+
+        $this->assertEquals('join_column', $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['name']);
+        $this->assertEquals('other_reference',
+            $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['referencedColumnName']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['nullable']);
+        $this->assertTrue($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['unique']);
     }
 
     public function test_can_set_foreign_key()
@@ -72,6 +86,20 @@ class ManyToManyTest extends RelationTestCase
         $this->assertEquals('other_reference',
             $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['referencedColumnName']);
         $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['nullable']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['unique']);
+    }
+
+    public function test_can_set_unique_foreign_key()
+    {
+        $this->relation->foreignKey('foreign_key', 'other_reference', true);
+
+        $this->relation->build();
+
+        $this->assertEquals('foreign_key', $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['name']);
+        $this->assertEquals('other_reference',
+            $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['referencedColumnName']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['nullable']);
+        $this->assertTrue($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['unique']);
     }
 
     public function test_can_set_source()
@@ -84,6 +112,20 @@ class ManyToManyTest extends RelationTestCase
         $this->assertEquals('other_reference',
             $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['referencedColumnName']);
         $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['nullable']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['unique']);
+    }
+
+    public function test_can_set_unique_source()
+    {
+        $this->relation->source('source', 'other_reference', true);
+
+        $this->relation->build();
+
+        $this->assertEquals('source', $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['name']);
+        $this->assertEquals('other_reference',
+            $this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['referencedColumnName']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['nullable']);
+        $this->assertTrue($this->getAssocValue($this->field, 'joinTable')['joinColumns'][0]['unique']);
     }
 
     public function test_can_set_inverseKey()
@@ -97,6 +139,21 @@ class ManyToManyTest extends RelationTestCase
         $this->assertEquals('other_reference',
             $this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['referencedColumnName']);
         $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['nullable']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['unique']);
+    }
+
+    public function test_can_set_unique_inverseKey()
+    {
+        $this->relation->inverseKey('inverse_key', 'other_reference', true);
+
+        $this->relation->build();
+
+        $this->assertEquals('inverse_key',
+            $this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['name']);
+        $this->assertEquals('other_reference',
+            $this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['referencedColumnName']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['nullable']);
+        $this->assertTrue($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['unique']);
     }
 
     public function test_can_set_target()
@@ -109,6 +166,20 @@ class ManyToManyTest extends RelationTestCase
         $this->assertEquals('other_reference',
             $this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['referencedColumnName']);
         $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['nullable']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['unique']);
+    }
+
+    public function test_can_set_unique_target()
+    {
+        $this->relation->target('target', 'other_reference', true);
+
+        $this->relation->build();
+
+        $this->assertEquals('target', $this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['name']);
+        $this->assertEquals('other_reference',
+            $this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['referencedColumnName']);
+        $this->assertFalse($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['nullable']);
+        $this->assertTrue($this->getAssocValue($this->field, 'joinTable')['inverseJoinColumns'][0]['unique']);
     }
 
     public function test_can_add_join_column()


### PR DESCRIPTION
This is known as a unidirectional inverse one-to-many through join table. 

See http://doctrine-orm.readthedocs.org/projects/doctrine-orm/en/latest/reference/association-mapping.html#one-to-many-unidirectional-with-join-table
