### PR TITLE
Renamed the `isReadOnly()` method to `readOnly()`

### DIFF
--- a/src/Builders/Entity.php
+++ b/src/Builders/Entity.php
@@ -21,7 +21,7 @@ class Entity extends AbstractBuilder
     /**
      * @return Entity
      */
-    public function isReadOnly()
+    public function readOnly()
     {
         $this->builder->setReadOnly();
 

--- a/tests/Builders/EntityTest.php
+++ b/tests/Builders/EntityTest.php
@@ -36,7 +36,7 @@ class EntityTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertFalse($this->builder->getClassMetadata()->isReadOnly);
 
-        $this->entity->isReadOnly();
+        $this->entity->readOnly();
 
         $this->assertTrue($this->builder->getClassMetadata()->isReadOnly);
     }


### PR DESCRIPTION
The "is" prefix can be confused with a boolean getter.
