### PR TITLE
hasOne implies an inverse one-to-one relation

### DIFF
--- a/src/Builders/Traits/Relations.php
+++ b/src/Builders/Traits/Relations.php
@@ -21,7 +21,9 @@ trait Relations
      */
     public function hasOne($entity, $field = null, callable $callback = null)
     {
-        return $this->oneToOne($entity, $field, $callback);
+        return $this->oneToOne($entity, $field, $callback)->ownedBy(
+            $this->guessSingularField($entity)
+        );
     }
 
     /**

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -525,6 +525,19 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertContains($relation, $this->fluent->getQueued());
     }
 
+    public function test_has_one_implies_an_inverse_one_to_one()
+    {
+        $relation = $this->fluent->hasOne(FakeEntity::class, 'one');
+
+        $relation->build();
+
+        $result = $this->builder->getClassMetadata()->associationMappings['one'];
+
+        $this->assertFalse($result['isOwningSide'],
+            "HasOne relation is an inversed one-to-one, but resulted in the owning side."
+        );
+    }
+
     public function test_can_add_one_to_one()
     {
         $relation = $this->fluent->oneToOne(FakeEntity::class, 'one', function ($relation) {


### PR DESCRIPTION
This means that the entity that maps as a `hasOne` is owned by the other one (probably mapped as a `belongsTo`)
