### PR TITLE
Duplicated method `$builder->setArray()` is not needed.

### DIFF
--- a/src/Builders/Traits/Fields.php
+++ b/src/Builders/Traits/Fields.php
@@ -230,17 +230,6 @@ trait Fields
      *
      * @return Field
      */
-    public function setArray($name, callable $callback = null)
-    {
-        return $this->field(Type::TARRAY, $name, $callback);
-    }
-
-    /**
-     * @param string        $name
-     * @param callable|null $callback
-     *
-     * @return Field
-     */
     public function simpleArray($name, callable $callback = null)
     {
         return $this->field(Type::SIMPLE_ARRAY, $name, $callback);
@@ -398,6 +387,17 @@ trait Fields
     public function rememberToken($name = 'rememberToken', callable $callback = null)
     {
         return $this->string($name, $callback)->nullable()->length(100);
+    }
+
+    /**
+     * @param string        $name
+     * @param callable|null $callback
+     *
+     * @return Field
+     */
+    protected function setArray($name, callable $callback = null)
+    {
+        return $this->field(Type::TARRAY, $name, $callback);
     }
 
     /**

--- a/src/Fluent.php
+++ b/src/Fluent.php
@@ -410,14 +410,6 @@ interface Fluent extends Buildable
      *
      * @return Field
      */
-    public function setArray($name, callable $callback = null);
-
-    /**
-     * @param string        $name
-     * @param callable|null $callback
-     *
-     * @return Field
-     */
     public function simpleArray($name, callable $callback = null);
 
     /**

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -75,7 +75,6 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         'guid'             => Type::GUID,
         'blob'             => Type::BLOB,
         'array'            => Type::TARRAY,
-        'setArray'         => Type::TARRAY,
         'simpleArray'      => Type::SIMPLE_ARRAY,
     ];
 


### PR DESCRIPTION
Made protected in favor of the `array()` method.
