### PR TITLE
Duplicated method `$field->setDefault()` is not needed.

### DIFF
--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -130,20 +130,6 @@ class Field implements Buildable
     }
 
     /**
-     * The default value to set for the column if no value is supplied.
-     *
-     * @param string $default
-     *
-     * @return Field
-     */
-    public function setDefault($default)
-    {
-        $this->builder->option('default', $default);
-
-        return $this;
-    }
-
-    /**
      * Boolean value to determine if the specified length of a string column should be fixed or varying
      * (applies only for string/binary column and might not be supported by all vendors).
      *
@@ -247,5 +233,19 @@ class Field implements Buildable
         }
 
         throw new BadMethodCallException("FieldBuilder method [{$method}] does not exist.");
+    }
+
+    /**
+     * The default value to set for the column if no value is supplied.
+     *
+     * @param string $default
+     *
+     * @return Field
+     */
+    protected function setDefault($default)
+    {
+        $this->builder->option('default', $default);
+
+        return $this;
     }
 }

--- a/tests/Builders/FieldTest.php
+++ b/tests/Builders/FieldTest.php
@@ -120,23 +120,13 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->builder->getClassMetadata()->getFieldMapping('name')['options']['unsigned']);
     }
 
-    public function test_can_set_default()
+    public function test_can_set_default_fluently()
     {
-        $this->field->setDefault('default');
+        $this->field->default('default');
 
         $this->field->build();
 
         $this->assertEquals('default',
-            $this->builder->getClassMetadata()->getFieldMapping('name')['options']['default']);
-    }
-
-    public function test_can_set_default_fluently()
-    {
-        $this->field->default('default2');
-
-        $this->field->build();
-
-        $this->assertEquals('default2',
             $this->builder->getClassMetadata()->getFieldMapping('name')['options']['default']);
     }
 


### PR DESCRIPTION
Made protected in favor of the `default()` method.
