### PR TITLE
Integrated Mockery through the TestListener

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,4 +20,7 @@
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
+    <listeners>
+        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
+    </listeners>
 </phpunit>

--- a/tests/Mappers/EntityMapperTest.php
+++ b/tests/Mappers/EntityMapperTest.php
@@ -50,9 +50,4 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertContains(StubEntity::class, $metadata->associationMappings['one']['targetEntity']);
         $this->assertContains(StubEntity::class, $metadata->associationMappings['many']['targetEntity']);
     }
-
-    protected function tearDown()
-    {
-        m::close();
-    }
 }


### PR DESCRIPTION
As documented on http://docs.mockery.io/en/latest/reference/phpunit_integration.html

I make this as a PR because using the TestListener has a known issue: It doesn't work when running tests with `processIsolation`. We don't need to, but if we ever **do**, we'll have to remember to call `\Mockery::close()` on that class manually.
