### PR TITLE
Table options support

### DIFF
--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -34,6 +34,8 @@ class Builder extends AbstractBuilder implements Fluent
 
         $this->callIfCallable($callback, $table);
 
+        $table->build();
+
         return $table;
     }
 

--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -32,9 +32,7 @@ class Builder extends AbstractBuilder implements Fluent
 
         $table = new Table($this->builder, $name);
 
-        $this->callIfCallable($callback, $table);
-
-        $table->build();
+        $this->callbackAndQueue($table, $callback);
 
         return $table;
     }

--- a/src/Builders/Table.php
+++ b/src/Builders/Table.php
@@ -3,9 +3,15 @@
 namespace LaravelDoctrine\Fluent\Builders;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use LaravelDoctrine\Fluent\Buildable;
 
-class Table extends AbstractBuilder
+class Table extends AbstractBuilder implements Buildable
 {
+    /**
+     * @var array
+     */
+    protected $primaryTable = [];
+
     /**
      * @param ClassMetadataBuilder $builder
      * @param string|callable|null $name
@@ -40,7 +46,31 @@ class Table extends AbstractBuilder
      */
     public function schema($schema)
     {
-        $this->builder->getClassMetadata()->setPrimaryTable(['schema' => $schema]);
+        $this->primaryTable['schema'] = $schema;
+
+        return $this;
+    }
+
+    /**
+     * @param string $charset
+     *
+     * @return $this
+     */
+    public function charset($charset)
+    {
+        $this->option('charset', $charset);
+
+        return $this;
+    }
+
+    /**
+     * @param string $collate
+     *
+     * @return $this
+     */
+    public function collate($collate)
+    {
+        $this->option('collate', $collate);
 
         return $this;
     }
@@ -50,10 +80,31 @@ class Table extends AbstractBuilder
      *
      * @return $this
      */
-    public function setOptions(array $options = [])
+    public function options(array $options = [])
     {
-        $this->builder->getClassMetadata()->setPrimaryTable(['options' => $options]);
+        $this->primaryTable['options'] = $options;
 
         return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function option($name, $value)
+    {
+        $this->primaryTable['options'][$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Execute the build process
+     */
+    public function build()
+    {
+        $this->builder->getClassMetadata()->setPrimaryTable($this->primaryTable);
     }
 }

--- a/src/Builders/Table.php
+++ b/src/Builders/Table.php
@@ -4,9 +4,14 @@ namespace LaravelDoctrine\Fluent\Builders;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use LaravelDoctrine\Fluent\Buildable;
+use LaravelDoctrine\Fluent\Builders\Traits\Queueable;
 
 class Table extends AbstractBuilder implements Buildable
 {
+    use Queueable {
+        build as buildQueued;
+    }
+
     /**
      * @var array
      */

--- a/src/Builders/Table.php
+++ b/src/Builders/Table.php
@@ -44,4 +44,16 @@ class Table extends AbstractBuilder
 
         return $this;
     }
+
+    /**
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function setOptions(array $options = [])
+    {
+        $this->builder->getClassMetadata()->setPrimaryTable(['options' => $options]);
+
+        return $this;
+    }
 }

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -120,4 +120,16 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('utf8mb4_unicode_ci', $this->builder->getClassMetadata()->table['options']['collate']);
     }
+
+    public function test_can_chain_collate_charset_schema() {
+        $this->table->collate('utf8mb4_unicode_ci')->charset('utf8mb4')->schema('a_schema');
+
+        $this->table->build();
+
+        $this->assertEquals('a_schema', $this->builder->getClassMetadata()->table['schema']);
+        $this->assertEquals([
+            'collate' => 'utf8mb4_unicode_ci',
+            'charset' => 'utf8mb4'
+        ], $this->builder->getClassMetadata()->table['options']);
+    }
 }

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -88,4 +88,12 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($table, $this->builder->getClassMetadata()->table);
     }
+
+    public function test_can_set_options_and_change_schema () {
+        $this->table->setOptions(['collate' => 'utf8mb4_unicode_ci']);
+        $this->table->schema('a_schema');
+
+        $this->assertEquals('a_schema', $this->builder->getClassMetadata()->getSchemaName());
+        $this->assertEquals(['collate' => 'utf8mb4_unicode_ci'], $this->builder->getClassMetadata()->table['options']);
+    }
 }

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -64,15 +64,19 @@ class TableTest extends \PHPUnit_Framework_TestCase
     {
         $this->table->schema('a_schema');
 
+        $this->table->build();
+
         $this->assertEquals('a_schema', $this->builder->getClassMetadata()->getSchemaName());
     }
 
     public function test_can_set_options()
     {
-        $this->table->setOptions([
+        $this->table->options([
             'collate' => 'utf8mb4_unicode_ci',
             'charset' => 'utf8mb4'
         ]);
+
+        $this->table->build();
 
         $this->assertEquals([
             'collate' => 'utf8mb4_unicode_ci',
@@ -83,15 +87,19 @@ class TableTest extends \PHPUnit_Framework_TestCase
     public function test_set_options_does_not_touch_other_data() {
         $table = $this->table->getClassMetadata()->table;
 
-        $this->table->setOptions(['collate' => 'utf8mb4_unicode_ci']);
+        $this->table->options(['collate' => 'utf8mb4_unicode_ci']);
         $table['options'] = ['collate' => 'utf8mb4_unicode_ci'];
+
+        $this->table->build();
 
         $this->assertEquals($table, $this->builder->getClassMetadata()->table);
     }
 
     public function test_can_set_options_and_change_schema () {
-        $this->table->setOptions(['collate' => 'utf8mb4_unicode_ci']);
+        $this->table->options(['collate' => 'utf8mb4_unicode_ci']);
         $this->table->schema('a_schema');
+
+        $this->table->build();
 
         $this->assertEquals('a_schema', $this->builder->getClassMetadata()->getSchemaName());
         $this->assertEquals(['collate' => 'utf8mb4_unicode_ci'], $this->builder->getClassMetadata()->table['options']);

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -104,4 +104,20 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('a_schema', $this->builder->getClassMetadata()->getSchemaName());
         $this->assertEquals(['collate' => 'utf8mb4_unicode_ci'], $this->builder->getClassMetadata()->table['options']);
     }
+
+    public function test_can_set_charset() {
+        $this->table->charset('utf8mb4');
+
+        $this->table->build();
+
+        $this->assertEquals('utf8mb4', $this->builder->getClassMetadata()->table['options']['charset']);
+    }
+
+    public function test_can_set_collate() {
+        $this->table->collate('utf8mb4_unicode_ci');
+
+        $this->table->build();
+
+        $this->assertEquals('utf8mb4_unicode_ci', $this->builder->getClassMetadata()->table['options']['collate']);
+    }
 }

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -66,4 +66,26 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('a_schema', $this->builder->getClassMetadata()->getSchemaName());
     }
+
+    public function test_can_set_options()
+    {
+        $this->table->setOptions([
+            'collate' => 'utf8mb4_unicode_ci',
+            'charset' => 'utf8mb4'
+        ]);
+
+        $this->assertEquals([
+            'collate' => 'utf8mb4_unicode_ci',
+            'charset' => 'utf8mb4'
+        ], $this->builder->getClassMetadata()->table['options']);
+    }
+
+    public function test_set_options_does_not_touch_other_data() {
+        $table = $this->table->getClassMetadata()->table;
+
+        $this->table->setOptions(['collate' => 'utf8mb4_unicode_ci']);
+        $table['options'] = ['collate' => 'utf8mb4_unicode_ci'];
+
+        $this->assertEquals($table, $this->builder->getClassMetadata()->table);
+    }
 }


### PR DESCRIPTION
- [x] Add support for table options

Adds support for setting e.g. `engine`, `collate` and `charset` table options.

``` php
    $builder->table('foo', function(Table $table) {
        $table->setOptions(['charset' => 'utf8mb']);
    })
```
