### PR TITLE
Locale has to be set on builder level

### DIFF
--- a/src/Extensions/Gedmo/GedmoBuilderHints.php
+++ b/src/Extensions/Gedmo/GedmoBuilderHints.php
@@ -11,6 +11,7 @@ namespace LaravelDoctrine\Fluent\Extensions\Gedmo;
  * @method TranslationClass translationClass(string $class)
  * @method Tree             tree(callable $callback = null)
  * @method Uploadable       uploadable()
+ * @method void             locale(string $fieldName)
  */
 trait GedmoBuilderHints
 {

--- a/src/Extensions/Gedmo/GedmoFieldHints.php
+++ b/src/Extensions/Gedmo/GedmoFieldHints.php
@@ -7,7 +7,6 @@ namespace LaravelDoctrine\Fluent\Extensions\Gedmo;
  *
  * @method Blameable      blameable()
  * @method IpTraceable    ipTraceable()
- * @method void           locale()
  * @method Sluggable      sluggable(mixed $fields)
  * @method SoftDeleteable softDelete()
  * @method void           sortableGroup()

--- a/src/Extensions/Gedmo/Locale.php
+++ b/src/Extensions/Gedmo/Locale.php
@@ -6,10 +6,11 @@ use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Translatable\Mapping\Driver\Fluent as FluentDriver;
 use LaravelDoctrine\Fluent\Buildable;
 use LaravelDoctrine\Fluent\Builders\Builder;
-use LaravelDoctrine\Fluent\Builders\Field;
+use LaravelDoctrine\Fluent\Builders\Delay;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
+use LaravelDoctrine\Fluent\Extensions\Extension;
 
-class Locale implements Buildable
+class Locale implements Buildable, Extension, Delay
 {
     const MACRO_METHOD = 'locale';
 

--- a/src/Extensions/Gedmo/Locale.php
+++ b/src/Extensions/Gedmo/Locale.php
@@ -2,8 +2,10 @@
 
 namespace LaravelDoctrine\Fluent\Extensions\Gedmo;
 
+use Gedmo\Exception\InvalidMappingException;
 use Gedmo\Translatable\Mapping\Driver\Fluent as FluentDriver;
 use LaravelDoctrine\Fluent\Buildable;
+use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 
@@ -37,8 +39,8 @@ class Locale implements Buildable
      */
     public static function enable()
     {
-        Field::macro(self::MACRO_METHOD, function (Field $field) {
-            return new static($field->getClassMetadata(), $field->getName());
+        Builder::macro(self::MACRO_METHOD, function (Builder $builder, $fieldName) {
+            return new static($builder->getClassMetadata(), $fieldName);
         });
     }
 
@@ -47,8 +49,14 @@ class Locale implements Buildable
      */
     public function build()
     {
+        if ($this->classMetadata->hasField($this->fieldName)) {
+            throw new InvalidMappingException(
+                "Locale field [{$this->fieldName}] should not be mapped as column property in entity - {$this->classMetadata->name}, since it makes no sense"
+            );
+        }
+
         $this->classMetadata->appendExtension($this->getExtensionName(), [
-            'locale' => $this->fieldName
+            'locale' => $this->fieldName,
         ]);
     }
 

--- a/src/Fluent.php
+++ b/src/Fluent.php
@@ -12,6 +12,7 @@ namespace LaravelDoctrine\Fluent;
  * @method Extensions\Gedmo\TranslationClass translationClass(string $class)
  * @method Extensions\Gedmo\Tree             tree(callable $callback = null)
  * @method Extensions\Gedmo\Uploadable       uploadable()
+ * @method                                   locale(string $fieldName)
  */
 interface Fluent extends Buildable
 {

--- a/tests/Extensions/Gedmo/LocaleTest.php
+++ b/tests/Extensions/Gedmo/LocaleTest.php
@@ -64,10 +64,19 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_fail_when_trying_to_use_a_mapped_field_as_locale()
     {
+        $this->setExpectedException(InvalidMappingException::class);
         $this->builder->string('language');
         $this->builder->locale('language');
 
+        $this->builder->build();
+    }
+
+    public function test_it_should_fail_when_trying_to_use_a_mapped_field_as_locale_even_if_its_mapped_afterwards()
+    {
         $this->setExpectedException(InvalidMappingException::class);
+        $this->builder->locale('language');
+        $this->builder->string('language');
+
         $this->builder->build();
     }
 

--- a/tests/Extensions/Gedmo/LocaleTest.php
+++ b/tests/Extensions/Gedmo/LocaleTest.php
@@ -3,11 +3,11 @@
 namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
-use LaravelDoctrine\Fluent\Builders\Field;
+use Gedmo\Exception\InvalidMappingException;
+use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Locale;
-use LaravelDoctrine\Fluent\Extensions\Gedmo\Translatable;
 
 /**
  * @mixin \PHPUnit_Framework_TestCase
@@ -25,30 +25,31 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
     protected $classMetadata;
 
     /**
-     * @var Translatable
+     * @var Locale
      */
-    private $extension;
+    protected $extension;
+
+    /**
+     * @var Builder
+     */
+    protected $builder;
 
     protected function setUp()
     {
+        Locale::enable();
+
         $this->fieldName     = 'locale';
         $this->classMetadata = new ExtensibleClassMetadata('foo');
-        Field::make(new ClassMetadataBuilder($this->classMetadata), 'string', 'locale')->build();
+        $this->builder       = new Builder(new ClassMetadataBuilder($this->classMetadata));
 
         $this->extension = new Locale($this->classMetadata, $this->fieldName);
     }
 
-    public function test_it_should_add_itself_as_a_field_macro()
+    public function test_it_should_add_itself_as_a_builder_macro()
     {
-        Locale::enable();
-
-        $field = Field::make(new ClassMetadataBuilder(
-            new ExtensibleClassMetadata('Foo')), 'string', $this->fieldName
-        )->build();
-
         $this->assertInstanceOf(
             Locale::class,
-            call_user_func([$field, Locale::MACRO_METHOD])
+            call_user_func([$this->builder, Locale::MACRO_METHOD], 'language')
         );
     }
 
@@ -57,9 +58,19 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
         $this->getExtension()->build();
 
         $this->assertBuildResultIs([
-            'locale' => 'locale',
+            'locale' => $this->fieldName,
         ]);
     }
+
+    public function test_it_should_fail_when_trying_to_use_a_mapped_field_as_locale()
+    {
+        $this->builder->string('language');
+        $this->builder->locale('language');
+
+        $this->setExpectedException(InvalidMappingException::class);
+        $this->builder->build();
+    }
+
 
     /**
      * Assert that the resulting build matches exactly with the given array.

--- a/tests/Extensions/GedmoExtensionsTest.php
+++ b/tests/Extensions/GedmoExtensionsTest.php
@@ -213,7 +213,6 @@ class GedmoExtensionsTest extends PHPUnit_Framework_TestCase
         return [
             ['blameable'],
             ['ipTraceable'],
-            ['locale'],
             ['sluggable'],
             ['softDelete'],
             ['sortableGroup'],
@@ -245,6 +244,7 @@ class GedmoExtensionsTest extends PHPUnit_Framework_TestCase
             ['translationClass'],
             ['tree'],
             ['uploadable'],
+            ['locale'],
         ];
     }
 


### PR DESCRIPTION
It actually cannot be set on a mapped field, as "it makes no sense".

See https://github.com/Atlantic18/DoctrineExtensions/blob/master/lib/Gedmo/Translatable/Mapping/Driver/Annotation.php#L79
