### PR TITLE
Ignore tests folder on git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests export-ignore


### PR DESCRIPTION
This prevents downloading the tests suite when the project is required as a dependency