### PR TITLE
Convert paths into Mapping objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=5.6.0",
     "doctrine/orm": "2.5.*",
     "doctrine/inflector": "^1.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "gedmo/doctrine-extensions": "^2.4"
   },
   "autoload": {
+    "files": ["src/helpers.php"],
     "psr-4": {
       "LaravelDoctrine\\Fluent\\": "src/",
       "Gedmo\\": "lib/"

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -81,6 +81,7 @@ class FluentDriver implements MappingDriver
      * Adds an array of mapping classes / objects to the driver.
      *
      * @param string[]|Mapping[] $mappings
+     *
      * @throws MappingException
      * @throws InvalidArgumentException
      */
@@ -96,6 +97,7 @@ class FluentDriver implements MappingDriver
      *
      * @throws MappingException
      * @throws InvalidArgumentException
+     *
      * @return void
      */
     public function addMapping($mapping)
@@ -138,9 +140,11 @@ class FluentDriver implements MappingDriver
     /**
      * Create a mapping object from a mapping class, assuming an empty constructor.
      *
-     * @param  string $class
-     * @return Mapping
+     * @param string $class
+     *
      * @throws InvalidArgumentException
+     *
+     * @return Mapping
      */
     protected function createMapping($class)
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -13,13 +13,15 @@ use RegexIterator;
 /**
  * Returns an array of Mapping objects found on the given paths.
  *
- * @param  string[] $paths
- * @param  string   $fileExtension
- * @return Mapping[]
+ * @param string[] $paths
+ * @param string   $fileExtension
  *
  * @throws MappingException
+ *
+ * @return Mapping[]
  */
-function mappingsFrom(array $paths, $fileExtension = '.php') {
+function mappingsFrom(array $paths, $fileExtension = '.php')
+{
     $includedFiles = [];
 
     foreach ($paths as $path) {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace LaravelDoctrine\Fluent;
+
+use Doctrine\ORM\Mapping\MappingException;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveRegexIterator;
+use ReflectionClass;
+use RegexIterator;
+
+/**
+ * Returns an array of Mapping objects found on the given paths.
+ *
+ * @param  string[] $paths
+ * @param  string   $fileExtension
+ * @return Mapping[]
+ *
+ * @throws MappingException
+ */
+function mappingsFrom(array $paths, $fileExtension = '.php') {
+    $includedFiles = [];
+
+    foreach ($paths as $path) {
+        if (!is_dir($path)) {
+            throw MappingException::fileMappingDriversRequireConfiguredDirectoryPath($path);
+        }
+
+        $iterator = new RegexIterator(
+            new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::LEAVES_ONLY
+            ),
+            '/^.+'.preg_quote($fileExtension, '/').'$/i',
+            RecursiveRegexIterator::GET_MATCH
+        );
+
+        foreach ($iterator as $file) {
+            $sourceFile = $file[0];
+
+            if (!preg_match('(^phar:)i', $sourceFile)) {
+                $sourceFile = realpath($sourceFile);
+            }
+
+            require_once $sourceFile;
+
+            $includedFiles[$sourceFile] = true;
+        }
+    }
+
+    $mappings = [];
+    $declared = get_declared_classes();
+    foreach ($declared as $className) {
+        $rc = new ReflectionClass($className);
+        $sourceFile = $rc->getFileName();
+        if ($sourceFile === false || !array_key_exists($sourceFile, $includedFiles)) {
+            continue;
+        }
+
+        if ($rc->isAbstract() || $rc->isInterface()) {
+            continue;
+        }
+
+        if (!$rc->implementsInterface(Mapping::class)) {
+            continue;
+        }
+
+        $mappings[] = $rc->newInstanceWithoutConstructor();
+    }
+
+    return $mappings;
+}

--- a/tests/FluentDriverTest.php
+++ b/tests/FluentDriverTest.php
@@ -19,6 +19,7 @@ use Tests\Stubs\MappedSuperClasses\StubMappedSuperClass;
 use Tests\Stubs\Mappings\StubEmbeddableMapping;
 use Tests\Stubs\Mappings\StubEntityMapping;
 use Tests\Stubs\Mappings\StubMappedSuperClassMapping;
+use function LaravelDoctrine\Fluent\mappingsFrom;
 
 class FluentDriverTest extends \PHPUnit_Framework_TestCase
 {
@@ -228,6 +229,53 @@ class FluentDriverTest extends \PHPUnit_Framework_TestCase
 
         $driver->getMappers()->addMapper('fake', new EntityMapper($mapping));
         $driver->loadMetadataForClass('fake', new ClassMetadataInfo('fake'));
+    }
+
+    /**
+     * This is not "only" a FluentDriver test.
+     * This tests the `mappingsFrom` function, in conjunction with the driver's ability
+     * to receive both Mapping class names or Mapping objects.
+     */
+    public function test_it_can_be_built_with_paths_using_the_provided_helper()
+    {
+        $driver = new FluentDriver(array_merge(
+            mappingsFrom([__DIR__ . '/Stubs/Mappings']),
+            [FakeClassMapping::class]
+        ));
+
+        $classNames = $driver->getAllClassNames();
+        $this->assertContains(StubEntity::class, $classNames);
+        $this->assertContains(StubEmbeddable::class, $classNames);
+        $this->assertContains(StubMappedSuperClass::class, $classNames);
+        $this->assertContains(FakeEntity::class, $classNames);
+
+        $driver->loadMetadataForClass(
+            StubEntity::class, new ClassMetadataInfo(StubEntity::class)
+        );
+        $this->assertInstanceOf(
+            EntityMapper::class, $driver->getMappers()->getMapperFor(StubEntity::class)
+        );
+
+        $driver->loadMetadataForClass(
+            StubEmbeddable::class, new ClassMetadataInfo(StubEmbeddable::class)
+        );
+        $this->assertInstanceOf(
+            EmbeddableMapper::class, $driver->getMappers()->getMapperFor(StubEmbeddable::class)
+        );
+
+        $driver->loadMetadataForClass(
+            StubMappedSuperClass::class, new ClassMetadataInfo(StubMappedSuperClass::class)
+        );
+        $this->assertInstanceOf(
+            MappedSuperClassMapper::class, $driver->getMappers()->getMapperFor(StubMappedSuperClass::class)
+        );
+
+        $driver->loadMetadataForClass(
+            FakeEntity::class, new ClassMetadataInfo(FakeEntity::class)
+        );
+        $this->assertInstanceOf(
+            EntityMapper::class, $driver->getMappers()->getMapperFor(FakeEntity::class)
+        );
     }
 }
 


### PR DESCRIPTION
This PR adds a function that can convert an array of paths into an array of Mapping objects by reflecting on declared classes, just as the AnnotationDriver does.

The FluentDriver API is almost unchanged. To support receiving already-instanced Mapping objects, the `addMapping` methods had to be relaxed. Took the opportunity to refactor that relaxation to the lowest-level method, but this could be rolled back if BC matters.

We are debating between this and #48 :smile: 