### PR TITLE
Fixed naming dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require-dev": {
     "phpunit/phpunit": "~4.0",
     "mockery/mockery": "~0.9",
-    "beberlei/DoctrineExtensions": "~1.0",
+    "beberlei/doctrineextensions": "~1.0",
     "zf1/zend-date": "~1.12",
     "nesbot/carbon": "*",
     "gedmo/doctrine-extensions": "^2.4"


### PR DESCRIPTION
beberlei/DoctrineExtensions => beberlei/doctrineextensions

Composer yells at me that

```sh
 Deprecation warning: require-dev.beberlei/DoctrineExtensions is invalid, it should not contain uppercase characters. Please use beberlei/doctrineextensions instead. Make sure you fix this as Composer 2.0 will error.
```