### PR TITLE
drop support for outdated php versions and doctrine packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
   - 7.2
+  - 7.3
+  - 7.4
+
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
-    "doctrine/orm": "2.5.*|2.6.*|2.7.*",
-    "doctrine/inflector": "^1.1"
+    "php": "^7.2",
+    "doctrine/orm": "2.7.*",
+    "doctrine/inflector": "^1.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Php versions from 5.5 to 7.1 are not supported so it only makes headache to support them
same thing for `doctrine/orm` 2.5-2.6 and `doctrine/inflector` 1.1-1.2

ATTENTION! 
this PR is for the new version `1.2`