### PR TITLE
Upgrading PHPUnit to version 9 in preparation for PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     "doctrine/persistence": "^1.3.5|^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.0",
-    "mockery/mockery": "~0.9",
+    "phpunit/phpunit": "~8.0|~9.0",
+    "mockery/mockery": "~1.0",
     "beberlei/doctrineextensions": "~1.0",
     "zf1/zend-date": "~1.12",
     "nesbot/carbon": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
@@ -8,18 +9,17 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
-        >
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
     <listeners>
         <listener class="\Mockery\Adapter\Phpunit\TestListener" />
     </listeners>

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -32,13 +32,15 @@ use LaravelDoctrine\Fluent\Relations\OneToMany;
 use LaravelDoctrine\Fluent\Relations\OneToOne;
 use LaravelDoctrine\Fluent\Relations\Relation;
 use LogicException;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use Tests\FakeEntity;
 use Tests\Stubs\Embedabbles\StubEmbeddable;
 use Tests\Stubs\StubEntityListener;
 
-class BuilderTest extends \PHPUnit_Framework_TestCase
+class BuilderTest extends TestCase
 {
-    use IsMacroable;
+    use IsMacroable, MockeryPHPUnitIntegration;
 
     /**
      * @var ClassMetadataBuilder
@@ -82,7 +84,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         'simpleArray'      => Type::SIMPLE_ARRAY,
     ];
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Type::addType(CarbonDateTimeType::CARBONDATETIME, CarbonDateTimeType::class);
         Type::addType(CarbonDateTimeTzType::CARBONDATETIMETZ, CarbonDateTimeTzType::class);
@@ -91,7 +93,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         Type::addType(ZendDateType::ZENDDATE, ZendDateType::class);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             FluentEntity::class
@@ -161,7 +163,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     public function test_cannot_use_table_settings_for_embeddable()
     {
         $this->builder->setEmbeddable();
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
 
         $this->fluent->table('users');
     }
@@ -222,7 +224,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->builder->setEmbeddable();
 
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
 
         $this->fluent->entity();
     }
@@ -374,7 +376,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->builder->setEmbeddable();
 
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
 
         $this->fluent->increments('id');
     }
@@ -383,7 +385,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->builder->setEmbeddable();
 
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
 
         $this->fluent->smallIncrements('id');
     }
@@ -392,7 +394,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     {
         $this->builder->setEmbeddable();
 
-        $this->setExpectedException(LogicException::class);
+        $this->expectException(LogicException::class);
 
         $this->fluent->bigIncrements('id');
     }
@@ -640,10 +642,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_fluent_builder_method_should_exist()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Fluent builder method [doesNotExist] does not exist'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fluent builder method [doesNotExist] does not exist');
 
         $this->fluent->doesNotExist();
     }
@@ -768,6 +768,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_one_to_one_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->oneToOne(FluentEntity::class);
 
         $this->fluent->build();
@@ -781,6 +783,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_has_one_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->hasOne(FluentEntity::class);
 
         $this->fluent->build();
@@ -794,6 +798,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_belongs_to_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->belongsTo(FluentEntity::class);
 
         $this->fluent->build();
@@ -807,6 +813,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_one_to_many_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->oneToMany(FluentEntity::class)->mappedBy('fluentEntity');
 
         $this->fluent->build();
@@ -820,6 +828,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_has_many_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->hasMany(FluentEntity::class)->mappedBy('fluentEntity');
 
         $this->fluent->build();
@@ -833,6 +843,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_many_to_many_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->manyToMany(FluentEntity::class);
 
         $this->fluent->build();
@@ -846,6 +858,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_guess_a_belongs_to_many_relation_name()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->fluent->belongsToMany(FluentEntity::class);
 
         $this->fluent->build();

--- a/tests/Builders/EmbeddedTest.php
+++ b/tests/Builders/EmbeddedTest.php
@@ -6,8 +6,9 @@ use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use LaravelDoctrine\Fluent\Builders\Embedded;
+use PHPUnit\Framework\TestCase;
 
-class EmbeddedTest extends \PHPUnit_Framework_TestCase
+class EmbeddedTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
@@ -19,7 +20,7 @@ class EmbeddedTest extends \PHPUnit_Framework_TestCase
      */
     protected $embedded;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             FluentEmbeddable::class

--- a/tests/Builders/EntityListenersTest.php
+++ b/tests/Builders/EntityListenersTest.php
@@ -6,11 +6,11 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\EntityListeners;
-use Symfony\Component\VarDumper\Cloner\Stub;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 use Tests\Stubs\StubEntityListener;
 
-class EntityListenersTest extends \PHPUnit_Framework_TestCase
+class EntityListenersTest extends TestCase
 {
     /**
      * @var EntityListeners
@@ -22,7 +22,7 @@ class EntityListenersTest extends \PHPUnit_Framework_TestCase
      */
     protected $fluent;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fluent = new ClassMetadataBuilder(
             new ClassMetadataInfo(StubEntity::class)

--- a/tests/Builders/EntityTest.php
+++ b/tests/Builders/EntityTest.php
@@ -6,12 +6,14 @@ use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\Entity;
 use LaravelDoctrine\Fluent\Builders\Traits\Macroable;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class EntityTest extends \PHPUnit_Framework_TestCase
+class EntityTest extends TestCase
 {
-    use IsMacroable;
-    
+    use IsMacroable, MockeryPHPUnitIntegration;
+
     /**
      * @var ClassMetadataBuilder
      */
@@ -22,7 +24,7 @@ class EntityTest extends \PHPUnit_Framework_TestCase
      */
     protected $entity;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $this->entity  = new Entity($this->builder);
@@ -59,7 +61,7 @@ class EntityTest extends \PHPUnit_Framework_TestCase
 
     public function test_builder_method_should_exist()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->entity->doesNotExist();
     }

--- a/tests/Builders/FieldTest.php
+++ b/tests/Builders/FieldTest.php
@@ -11,12 +11,14 @@ use LaravelDoctrine\Fluent\Buildable;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Builders\GeneratedValue;
 use LaravelDoctrine\Fluent\Builders\Traits\Macroable;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class FieldTest extends \PHPUnit_Framework_TestCase
+class FieldTest extends TestCase
 {
-    use IsMacroable;
-    
+    use IsMacroable, MockeryPHPUnitIntegration;
+
     /**
      * @var ClassMetadataBuilder
      */
@@ -27,7 +29,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
      */
     protected $field;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $this->builder->setTable('stub_entities');
@@ -202,10 +204,8 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 
     public function test_cannot_call_non_existing_field_builder_methods()
     {
-        $this->setExpectedException(
-            BadMethodCallException::class,
-            'FieldBuilder method [nonExisting] does not exist.'
-        );
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('FieldBuilder method [nonExisting] does not exist.');
 
         $this->field->nonExisting();
     }
@@ -312,7 +312,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
 
     public function test_ids_cannot_be_used_for_versioning()
     {
-        $this->setExpectedException(MappingException::class);
+        $this->expectException(MappingException::class);
 
         $this->field
             ->primary()
@@ -327,7 +327,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
     
     public function test_buildable_objects_returned_from_macros_get_queued_and_built()
     {
-    	Field::macro('foo', function(){
+        Field::macro('foo', function(){
             /** @var Buildable|\Mockery\Mock $buildable */
             $buildable = \Mockery::mock(Buildable::class);
             $buildable->shouldReceive('build')->once();
@@ -356,7 +356,7 @@ class FieldTest extends \PHPUnit_Framework_TestCase
         $builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $field   = Field::make($builder, $type, "aField");
 
-        $this->setExpectedException(MappingException::class);
+        $this->expectException(MappingException::class);
         $field->useForVersioning()->build();
     }
 

--- a/tests/Builders/GeneratedValueTest.php
+++ b/tests/Builders/GeneratedValueTest.php
@@ -5,8 +5,9 @@ namespace Tests\Builders;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\GeneratedValue;
+use PHPUnit\Framework\TestCase;
 
-class GeneratedValueTest extends \PHPUnit_Framework_TestCase
+class GeneratedValueTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|FieldBuilder
@@ -23,7 +24,7 @@ class GeneratedValueTest extends \PHPUnit_Framework_TestCase
      */
     protected $fluent;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->field = $this->getMockBuilder(FieldBuilder::class)->disableOriginalConstructor()->getMock();
         $this->cm    = $this->getMockBuilder(ClassMetadataInfo::class)->disableOriginalConstructor()->getMock();

--- a/tests/Builders/IndexTest.php
+++ b/tests/Builders/IndexTest.php
@@ -5,16 +5,17 @@ namespace Tests\Builders;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\Index;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class IndexTest extends \PHPUnit_Framework_TestCase
+class IndexTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $this->builder->setTable('stub_entities');

--- a/tests/Builders/Inheritance/InheritanceFactoryTest.php
+++ b/tests/Builders/Inheritance/InheritanceFactoryTest.php
@@ -9,16 +9,17 @@ use LaravelDoctrine\Fluent\Builders\Inheritance\Inheritance;
 use LaravelDoctrine\Fluent\Builders\Inheritance\InheritanceFactory;
 use LaravelDoctrine\Fluent\Builders\Inheritance\JoinedTableInheritance;
 use LaravelDoctrine\Fluent\Builders\Inheritance\SingleTableInheritance;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class InheritanceFactoryTest extends \PHPUnit_Framework_TestCase
+class InheritanceFactoryTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             StubEntity::class
@@ -59,10 +60,8 @@ class InheritanceFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_only_create_joined_or_single_table_inheritance()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Inheritance type [NON_EXISTING] does not exist. SINGLE_TABLE and JOINED are support'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Inheritance type [NON_EXISTING] does not exist. SINGLE_TABLE and JOINED are support');
 
         InheritanceFactory::create('NON_EXISTING', $this->builder);
     }

--- a/tests/Builders/Inheritance/InheritanceTestCase.php
+++ b/tests/Builders/Inheritance/InheritanceTestCase.php
@@ -4,11 +4,12 @@ namespace Tests\Builders\Inheritance;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use LaravelDoctrine\Fluent\Builders\Inheritance\Inheritance;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 use Tests\Stubs\Entities\StubEntity2;
 use Tests\Stubs\Entities\StubEntity3;
 
-class InheritanceTestCase extends \PHPUnit_Framework_TestCase
+class InheritanceTestCase extends TestCase
 {
     /**
      * @var ClassMetadataBuilder

--- a/tests/Builders/Inheritance/JoinedTableInheritanceTest.php
+++ b/tests/Builders/Inheritance/JoinedTableInheritanceTest.php
@@ -19,7 +19,7 @@ class JoinedTableInheritanceTest extends InheritanceTestCase
      */
     protected $inheritance;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             StubEntity::class

--- a/tests/Builders/Inheritance/SingleTableInheritanceTest.php
+++ b/tests/Builders/Inheritance/SingleTableInheritanceTest.php
@@ -19,7 +19,7 @@ class SingleTableInheritanceTest extends InheritanceTestCase
      */
     protected $inheritance;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             StubEntity::class

--- a/tests/Builders/IsMacroable.php
+++ b/tests/Builders/IsMacroable.php
@@ -5,7 +5,7 @@ use InvalidArgumentException;
 use LaravelDoctrine\Fluent\Builders\Traits\Macroable;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
 trait IsMacroable
 {
@@ -33,10 +33,8 @@ trait IsMacroable
 
     public function test_can_only_be_extended_with_closures()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Macros should be used with a closure argument, none given'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Macros should be used with a closure argument, none given');
 
         call_user_func(
             [get_class($this->getMacroableBuilder()), 'macro'], 

--- a/tests/Builders/LifecycleEventsTest.php
+++ b/tests/Builders/LifecycleEventsTest.php
@@ -6,9 +6,10 @@ use Doctrine\ORM\Events;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\LifecycleEvents;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class LifecycleEventsTest extends \PHPUnit_Framework_TestCase
+class LifecycleEventsTest extends TestCase
 {
     /**
      * @var LifecycleEvents
@@ -20,7 +21,7 @@ class LifecycleEventsTest extends \PHPUnit_Framework_TestCase
      */
     protected $fluent;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fluent = new ClassMetadataBuilder(
             new ClassMetadataInfo(StubEntity::class)
@@ -71,7 +72,7 @@ class LifecycleEventsTest extends \PHPUnit_Framework_TestCase
 
     public function test_fluent_builder_method_should_exist()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->builder->onFlagerbert('breakStuff');
     }

--- a/tests/Builders/Overrides/AssociationOverrideTest.php
+++ b/tests/Builders/Overrides/AssociationOverrideTest.php
@@ -10,16 +10,17 @@ use InvalidArgumentException;
 use LaravelDoctrine\Fluent\Builders\Overrides\AssociationOverride;
 use LaravelDoctrine\Fluent\Relations\ManyToMany;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class AssociationOverrideTest extends \PHPUnit_Framework_TestCase
+class AssociationOverrideTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             StubEntity::class
@@ -31,10 +32,8 @@ class AssociationOverrideTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_instance_of_relation()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'The callback should return an instance of LaravelDoctrine\Fluent\Relations\Relation'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The callback should return an instance of LaravelDoctrine\Fluent\Relations\Relation');
 
         $override = $this->override('manyToMany', function () {
             return 'string';
@@ -45,10 +44,8 @@ class AssociationOverrideTest extends \PHPUnit_Framework_TestCase
 
     public function test_the_overridden_association_should_exist()
     {
-        $this->setExpectedException(
-            MappingException::class,
-            'No mapping found for field \'nonExisting\' on class \'Tests\Stubs\Entities\StubEntity\'.'
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('No mapping found for field \'nonExisting\' on class \'Tests\Stubs\Entities\StubEntity\'.');
 
         $override = $this->override('nonExisting', function () {
         });
@@ -58,10 +55,8 @@ class AssociationOverrideTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_only_override_many_to____relations()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'Only ManyToMany and ManyToOne relations can be overridden'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Only ManyToMany and ManyToOne relations can be overridden');
 
         $this->builder->addOwningOneToOne('oneToOne', StubEntity::class);
 

--- a/tests/Builders/Overrides/AttributeOverrideTest.php
+++ b/tests/Builders/Overrides/AttributeOverrideTest.php
@@ -8,16 +8,17 @@ use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\MappingException;
 use InvalidArgumentException;
 use LaravelDoctrine\Fluent\Builders\Overrides\AttributeOverride;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class AttributeOverrideTest extends \PHPUnit_Framework_TestCase
+class AttributeOverrideTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             StubEntity::class
@@ -28,10 +29,8 @@ class AttributeOverrideTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_return_instance_of_field()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'The callback should return an instance of LaravelDoctrine\Fluent\Builders\Field'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The callback should return an instance of LaravelDoctrine\Fluent\Builders\Field');
 
         $override = $this->override('attribute', function () {
             return 'string';
@@ -42,10 +41,8 @@ class AttributeOverrideTest extends \PHPUnit_Framework_TestCase
 
     public function test_the_overridden_field_should_exist()
     {
-        $this->setExpectedException(
-            MappingException::class,
-            'No mapping found for field \'non_existing\' on class \'Tests\Stubs\Entities\StubEntity\'.'
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('No mapping found for field \'non_existing\' on class \'Tests\Stubs\Entities\StubEntity\'.');
 
         $override = $this->override('non_existing', function () {
         });

--- a/tests/Builders/Overrides/OverrideBuilderFactoryTest.php
+++ b/tests/Builders/Overrides/OverrideBuilderFactoryTest.php
@@ -9,9 +9,10 @@ use InvalidArgumentException;
 use LaravelDoctrine\Fluent\Builders\Overrides\AssociationOverride;
 use LaravelDoctrine\Fluent\Builders\Overrides\AttributeOverride;
 use LaravelDoctrine\Fluent\Builders\Overrides\OverrideBuilderFactory;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class OverrideBuilderFactoryTest extends \PHPUnit_Framework_TestCase
+class OverrideBuilderFactoryTest extends TestCase
 {
     public function test_can_create_attribute_override()
     {
@@ -55,7 +56,8 @@ class OverrideBuilderFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_only_create_overrides_for_existing_attributes_or_relations()
     {
-        $this->setExpectedException(InvalidArgumentException::class,  'No attribute or association could be found for some_field');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No attribute or association could be found for some_field');
 
         $builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             StubEntity::class

--- a/tests/Builders/Overrides/OverrideTest.php
+++ b/tests/Builders/Overrides/OverrideTest.php
@@ -7,9 +7,10 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use LaravelDoctrine\Fluent\Builders\Delay;
 use LaravelDoctrine\Fluent\Builders\Overrides\Override;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class OverrideTest extends \PHPUnit_Framework_TestCase
+class OverrideTest extends TestCase
 {
     public function test_can_build_attribute_override()
     {

--- a/tests/Builders/PrimaryTest.php
+++ b/tests/Builders/PrimaryTest.php
@@ -5,16 +5,17 @@ namespace Tests\Builders;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\Primary;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class PrimaryTest extends \PHPUnit_Framework_TestCase
+class PrimaryTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $this->builder->setTable('stub_entities');

--- a/tests/Builders/TableTest.php
+++ b/tests/Builders/TableTest.php
@@ -5,9 +5,10 @@ namespace Tests\Builders;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\Table;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class TableTest extends \PHPUnit_Framework_TestCase
+class TableTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
@@ -19,7 +20,7 @@ class TableTest extends \PHPUnit_Framework_TestCase
      */
     protected $table;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $this->table   = new Table($this->builder);

--- a/tests/Builders/Traits/QueueableTest.php
+++ b/tests/Builders/Traits/QueueableTest.php
@@ -7,18 +7,22 @@ use LaravelDoctrine\Fluent\Builders\Delay;
 use LaravelDoctrine\Fluent\Builders\Traits\Macroable;
 use LaravelDoctrine\Fluent\Builders\Traits\Queueable;
 use LaravelDoctrine\Fluent\Builders\Traits\QueuesMacros;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LaravelDoctrine\Fluent\Builders\Traits\QueuesMacros
  */
-class QueueableTest extends \PHPUnit_Framework_TestCase
+class QueueableTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var QueueableClass
      */
     private $queueable;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->queueable = new QueueableClass();
     }

--- a/tests/Builders/UniqueConstraintTest.php
+++ b/tests/Builders/UniqueConstraintTest.php
@@ -5,16 +5,17 @@ namespace Tests\Builders;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\UniqueConstraint;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class UniqueConstraintTest extends \PHPUnit_Framework_TestCase
+class UniqueConstraintTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(StubEntity::class));
         $this->builder->setTable('stub_entities');

--- a/tests/Extensions/ExtensibleClassMetadataFactoryFactoryTest.php
+++ b/tests/Extensions/ExtensibleClassMetadataFactoryFactoryTest.php
@@ -6,10 +6,13 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadataFactory;
-use PHPUnit_Framework_TestCase;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-class ExtensibleClassMetadataFactoryTest extends PHPUnit_Framework_TestCase
+class ExtensibleClassMetadataFactoryFactoryTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     public function test_it_builds_extensible_class_metadata_objects()
     {
         $em = \Mockery::mock(EntityManager::class);

--- a/tests/Extensions/ExtensibleClassMetadataTest.php
+++ b/tests/Extensions/ExtensibleClassMetadataTest.php
@@ -4,16 +4,16 @@ namespace Tests\Extensions;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadata as ClassMetadataImplementation;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ExtensibleClassMetadataTest extends PHPUnit_Framework_TestCase
+class ExtensibleClassMetadataTest extends TestCase
 {
     /**
      * @var ExtensibleClassMetadata
      */
     private $cm;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->cm = new ExtensibleClassMetadata("Foo");
     }

--- a/tests/Extensions/Gedmo/BlameableTest.php
+++ b/tests/Extensions/Gedmo/BlameableTest.php
@@ -9,9 +9,9 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\AbstractTrackingExtension;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Blameable;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BlameableTest extends PHPUnit_Framework_TestCase
+class BlameableTest extends TestCase
 {
     use TrackingExtensions;
     
@@ -20,7 +20,7 @@ class BlameableTest extends PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         $this->extension     = new Blameable($this->classMetadata, $this->fieldName);

--- a/tests/Extensions/Gedmo/IpTraceableTest.php
+++ b/tests/Extensions/Gedmo/IpTraceableTest.php
@@ -7,9 +7,9 @@ use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\AbstractTrackingExtension;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\IpTraceable;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class IpTraceableTest extends PHPUnit_Framework_TestCase
+class IpTraceableTest extends TestCase
 {
     use TrackingExtensions;
     
@@ -18,7 +18,7 @@ class IpTraceableTest extends PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'ip';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/LocaleTest.php
+++ b/tests/Extensions/Gedmo/LocaleTest.php
@@ -4,15 +4,16 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Locale;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class LocaleTest extends \PHPUnit_Framework_TestCase
+class LocaleTest extends TestCase
 {
     /**
      * @var string
@@ -34,7 +35,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
      */
     protected $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         Locale::enable();
 
@@ -64,7 +65,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_fail_when_trying_to_use_a_mapped_field_as_locale()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
         $this->builder->string('language');
         $this->builder->locale('language');
 
@@ -73,7 +74,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_fail_when_trying_to_use_a_mapped_field_as_locale_even_if_its_mapped_afterwards()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
         $this->builder->locale('language');
         $this->builder->string('language');
 

--- a/tests/Extensions/Gedmo/LoggableTest.php
+++ b/tests/Extensions/Gedmo/LoggableTest.php
@@ -11,9 +11,9 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Loggable;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
 use LaravelDoctrine\Fluent\Relations\OneToOne;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class LoggableTest extends PHPUnit_Framework_TestCase
+class LoggableTest extends TestCase
 {
     /**
      * @var Loggable
@@ -25,7 +25,7 @@ class LoggableTest extends PHPUnit_Framework_TestCase
      */
     private $classMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         $this->loggable      = new Loggable($this->classMetadata);

--- a/tests/Extensions/Gedmo/Mappings/MappingTestCase.php
+++ b/tests/Extensions/Gedmo/Mappings/MappingTestCase.php
@@ -6,9 +6,13 @@ use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Builders\GeneratedValue;
 use LaravelDoctrine\Fluent\Fluent;
 use LaravelDoctrine\Fluent\Mapping;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-abstract class MappingTestCase extends \PHPUnit_Framework_TestCase
+abstract class MappingTestCase extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Mapping
      */
@@ -45,7 +49,7 @@ abstract class MappingTestCase extends \PHPUnit_Framework_TestCase
      */
     abstract protected function configureMocks();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $class = $this->getMappingClass();
         $this->mapping = new $class;

--- a/tests/Extensions/Gedmo/MaterializedPathTest.php
+++ b/tests/Extensions/Gedmo/MaterializedPathTest.php
@@ -12,9 +12,9 @@ use LaravelDoctrine\Fluent\Extensions\Gedmo\TreePath;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreePathHash;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreePathSource;
 use LaravelDoctrine\Fluent\Fluent;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MaterializedPathTest extends PHPUnit_Framework_TestCase
+class MaterializedPathTest extends TestCase
 {
     /**
      * @var ExtensibleClassMetadata
@@ -31,7 +31,7 @@ class MaterializedPathTest extends PHPUnit_Framework_TestCase
      */
     private $tree;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata("Foo");
         $this->builder       = new Builder(new ClassMetadataBuilder($this->classMetadata));

--- a/tests/Extensions/Gedmo/SluggableTest.php
+++ b/tests/Extensions/Gedmo/SluggableTest.php
@@ -3,17 +3,18 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidArgumentException;
+use Gedmo\Sluggable\Mapping\Driver\Fluent as SluggableDriver;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Sluggable\Mapping\Driver\Fluent as SluggableDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Sluggable;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class SluggableTest extends \PHPUnit_Framework_TestCase
+class SluggableTest extends TestCase
 {
     /**
      * @var ClassMetadataBuilder
@@ -35,7 +36,7 @@ class SluggableTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName = 'slug';
         $this->classMetadata = new ExtensibleClassMetadata(StubEntity::class);
@@ -56,7 +57,8 @@ class SluggableTest extends \PHPUnit_Framework_TestCase
 
     public function test_can_only_make_a_valid_field_sluggable()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Sluggable field is not a valid field type');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Sluggable field is not a valid field type');
 
         Sluggable::enable();
 

--- a/tests/Extensions/Gedmo/SoftDeleteableTest.php
+++ b/tests/Extensions/Gedmo/SoftDeleteableTest.php
@@ -2,17 +2,17 @@
 namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Gedmo\SoftDeleteable\Mapping\Driver\Fluent as SoftDeleteableDriver;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use LaravelDoctrine\Fluent\Extensions\Gedmo\AbstractTrackingExtension;
-use Gedmo\SoftDeleteable\Mapping\Driver\Fluent as SoftDeleteableDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\SoftDeleteable;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class SoftDeleteableTest extends \PHPUnit_Framework_TestCase
+class SoftDeleteableTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +29,7 @@ class SoftDeleteableTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'deletedAt';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/SortableGroupTest.php
+++ b/tests/Extensions/Gedmo/SortableGroupTest.php
@@ -10,8 +10,9 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\SortableGroup;
 use LaravelDoctrine\Fluent\Relations\ManyToMany;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
+use PHPUnit\Framework\TestCase;
 
-class SortableGroupTest extends \PHPUnit_Framework_TestCase
+class SortableGroupTest extends TestCase
 {
     /**
      * @var string
@@ -28,7 +29,7 @@ class SortableGroupTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'category';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/SortablePositionTest.php
+++ b/tests/Extensions/Gedmo/SortablePositionTest.php
@@ -7,8 +7,9 @@ use Gedmo\Sortable\Mapping\Driver\Fluent;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\SortablePosition;
+use PHPUnit\Framework\TestCase;
 
-class SortablePositionTest extends \PHPUnit_Framework_TestCase
+class SortablePositionTest extends TestCase
 {
     /**
      * @var string
@@ -25,7 +26,7 @@ class SortablePositionTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'position';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/SortableTest.php
+++ b/tests/Extensions/Gedmo/SortableTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Extensions\Gedmo;
 
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Sortable;
+use PHPUnit\Framework\TestCase;
 
-class SortableTest extends \PHPUnit_Framework_TestCase
+class SortableTest extends TestCase
 {
     public function test_enables_position_and_group()
     {
+        $this->expectNotToPerformAssertions();
+
         Sortable::enable();
     }
 }

--- a/tests/Extensions/Gedmo/TimestampableTest.php
+++ b/tests/Extensions/Gedmo/TimestampableTest.php
@@ -8,9 +8,9 @@ use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\AbstractTrackingExtension;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Timestampable;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class TimestampableTest extends PHPUnit_Framework_TestCase
+class TimestampableTest extends TestCase
 {
     use TrackingExtensions;
     
@@ -19,7 +19,7 @@ class TimestampableTest extends PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'ip';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/TrackingExtensions.php
+++ b/tests/Extensions/Gedmo/TrackingExtensions.php
@@ -6,7 +6,7 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\AbstractTrackingExtension;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
 trait TrackingExtensions
 {
@@ -33,7 +33,7 @@ trait TrackingExtensions
     
     public function test_it_should_fail_without_binding_which_event_to_use()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->getExtension()->build();
     }
@@ -122,7 +122,7 @@ trait TrackingExtensions
 
     public function test_it_should_not_allow_tracking_an_array_of_fields_with_a_specific_value_for_changes()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->getExtension()->onChange(['foobar', 'baz'], 'this_will_explode')->build();
     }

--- a/tests/Extensions/Gedmo/TranslatableTest.php
+++ b/tests/Extensions/Gedmo/TranslatableTest.php
@@ -2,15 +2,16 @@
 namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Translatable;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TranslatableTest extends \PHPUnit_Framework_TestCase
+class TranslatableTest extends TestCase
 {
     /**
      * @var string
@@ -27,7 +28,7 @@ class TranslatableTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'title';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/TranslationClassTest.php
+++ b/tests/Extensions/Gedmo/TranslationClassTest.php
@@ -4,16 +4,17 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Translatable\Mapping\Driver\Fluent as TranslatableDriver;
-use LaravelDoctrine\Fluent\Extensions\Gedmo\TranslationClass;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Translatable;
+use LaravelDoctrine\Fluent\Extensions\Gedmo\TranslationClass;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TranslationClassTest extends \PHPUnit_Framework_TestCase
+class TranslationClassTest extends TestCase
 {
     /**
      * @var string
@@ -30,7 +31,7 @@ class TranslationClassTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->className     = 'TranslationClass';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/TreeLeftTest.php
+++ b/tests/Extensions/Gedmo/TreeLeftTest.php
@@ -4,15 +4,16 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreeLeft;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreeLeftTest extends \PHPUnit_Framework_TestCase
+class TreeLeftTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +30,7 @@ class TreeLeftTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'lft';
         $this->classMetadata = new ExtensibleClassMetadata('foo');
@@ -63,7 +64,8 @@ class TreeLeftTest extends \PHPUnit_Framework_TestCase
 
     public function test_left_should_be_integer()
     {
-        $this->setExpectedException(InvalidMappingException::class, 'Tree left field must be \'integer\' in class - foo');
+        $this->expectException(InvalidMappingException::class);
+        $this->expectExceptionMessage('Tree left field must be \'integer\' in class - foo');
 
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         Field::make(new ClassMetadataBuilder($this->classMetadata), 'string', $this->fieldName)->build();

--- a/tests/Extensions/Gedmo/TreeLevelTest.php
+++ b/tests/Extensions/Gedmo/TreeLevelTest.php
@@ -4,15 +4,16 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreeLevel;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreeLevelTest extends \PHPUnit_Framework_TestCase
+class TreeLevelTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +30,7 @@ class TreeLevelTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'lvl';
         $this->classMetadata = new ExtensibleClassMetadata('foo');
@@ -63,7 +64,8 @@ class TreeLevelTest extends \PHPUnit_Framework_TestCase
 
     public function test_level_should_be_integer()
     {
-        $this->setExpectedException(InvalidMappingException::class, 'Tree level field must be \'integer\' in class - foo');
+        $this->expectException(InvalidMappingException::class);
+        $this->expectExceptionMessage('Tree level field must be \'integer\' in class - foo');
 
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         Field::make(new ClassMetadataBuilder($this->classMetadata), 'string', $this->fieldName)->build();

--- a/tests/Extensions/Gedmo/TreePathHashTest.php
+++ b/tests/Extensions/Gedmo/TreePathHashTest.php
@@ -3,16 +3,16 @@
 namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
-use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreePathHash;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreePathHashTest extends \PHPUnit_Framework_TestCase
+class TreePathHashTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +29,7 @@ class TreePathHashTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'hash';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/TreePathSourceTest.php
+++ b/tests/Extensions/Gedmo/TreePathSourceTest.php
@@ -4,15 +4,16 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreePathSource;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreePathSourceTest extends \PHPUnit_Framework_TestCase
+class TreePathSourceTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +30,7 @@ class TreePathSourceTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'source';
         $this->classMetadata = new ExtensibleClassMetadata('foo');
@@ -54,7 +55,8 @@ class TreePathSourceTest extends \PHPUnit_Framework_TestCase
 
     public function test_path_source_must_be_valid_field()
     {
-        $this->setExpectedException(InvalidMappingException::class, 'Tree PathSource field - [source] type is not valid. It can be any of the integer variants, double, float or string in class - foo');
+        $this->expectException(InvalidMappingException::class);
+        $this->expectExceptionMessage('Tree PathSource field - [source] type is not valid. It can be any of the integer variants, double, float or string in class - foo');
 
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         Field::make(new ClassMetadataBuilder($this->classMetadata), 'binary', $this->fieldName)->build();

--- a/tests/Extensions/Gedmo/TreePathTest.php
+++ b/tests/Extensions/Gedmo/TreePathTest.php
@@ -4,15 +4,16 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreePath;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreePathTest extends \PHPUnit_Framework_TestCase
+class TreePathTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +30,7 @@ class TreePathTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'path';
         $this->classMetadata = new ExtensibleClassMetadata('foo');
@@ -85,7 +86,8 @@ class TreePathTest extends \PHPUnit_Framework_TestCase
 
     public function test_separator_should_given()
     {
-        $this->setExpectedException(InvalidMappingException::class, 'Tree Path field - [path] Separator ||| is invalid. It must be only one character long.');
+        $this->expectException(InvalidMappingException::class);
+        $this->expectExceptionMessage('Tree Path field - [path] Separator ||| is invalid. It must be only one character long.');
 
         $this->getExtension()
              ->separator('|||')

--- a/tests/Extensions/Gedmo/TreeRightTest.php
+++ b/tests/Extensions/Gedmo/TreeRightTest.php
@@ -4,15 +4,16 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreeRight;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreeRightTest extends \PHPUnit_Framework_TestCase
+class TreeRightTest extends TestCase
 {
     /**
      * @var string
@@ -29,7 +30,7 @@ class TreeRightTest extends \PHPUnit_Framework_TestCase
      */
     private $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'rgt';
         $this->classMetadata = new ExtensibleClassMetadata('foo');
@@ -63,7 +64,8 @@ class TreeRightTest extends \PHPUnit_Framework_TestCase
 
     public function test_right_should_be_integer()
     {
-        $this->setExpectedException(InvalidMappingException::class, 'Tree right field must be \'integer\' in class - foo');
+        $this->expectException(InvalidMappingException::class);
+        $this->expectExceptionMessage('Tree right field must be \'integer\' in class - foo');
 
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         Field::make(new ClassMetadataBuilder($this->classMetadata), 'string', $this->fieldName)->build();

--- a/tests/Extensions/Gedmo/TreeSelfReferenceTest.php
+++ b/tests/Extensions/Gedmo/TreeSelfReferenceTest.php
@@ -4,16 +4,17 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreeSelfReference;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreeSelfReferenceTest extends \PHPUnit_Framework_TestCase
+class TreeSelfReferenceTest extends TestCase
 {
     /**
      * @var string
@@ -25,7 +26,7 @@ class TreeSelfReferenceTest extends \PHPUnit_Framework_TestCase
      */
     protected $classMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fieldName     = 'root';
         $this->classMetadata = new ExtensibleClassMetadata('foo');

--- a/tests/Extensions/Gedmo/TreeStrategyTest.php
+++ b/tests/Extensions/Gedmo/TreeStrategyTest.php
@@ -12,9 +12,13 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\TreeStrategy;
 use LaravelDoctrine\Fluent\Fluent;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
-abstract class TreeStrategyTest extends \PHPUnit_Framework_TestCase
+abstract class TreeStrategyTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var Fluent
      */
@@ -105,7 +109,7 @@ abstract class TreeStrategyTest extends \PHPUnit_Framework_TestCase
      */
     public function test_it_should_not_allow_strings_in_any_numeric_field($fieldName)
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->strategy->$fieldName('custom', 'string')->build();
     }

--- a/tests/Extensions/Gedmo/TreeTest.php
+++ b/tests/Extensions/Gedmo/TreeTest.php
@@ -4,20 +4,23 @@ namespace Tests\Extensions\Gedmo;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
-use Gedmo\Exception\InvalidMappingException;
+use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
-use Gedmo\Tree\Mapping\Driver\Fluent as TreeDriver;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\ClosureTable;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\MaterializedPath;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\NestedSet;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Tree;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @mixin \PHPUnit_Framework_TestCase
+ * @mixin TestCase
  */
-class TreeTest extends \PHPUnit_Framework_TestCase
+class TreeTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
+
     /**
      * @var string
      */
@@ -38,7 +41,7 @@ class TreeTest extends \PHPUnit_Framework_TestCase
      */
     private $builder;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         $this->builder       = new Builder(new ClassMetadataBuilder($this->classMetadata), new DefaultNamingStrategy);

--- a/tests/Extensions/Gedmo/UploadableFileTest.php
+++ b/tests/Extensions/Gedmo/UploadableFileTest.php
@@ -8,9 +8,9 @@ use Gedmo\Uploadable\Mapping\Driver\Fluent;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\UploadableFile;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UploadableFileTest extends PHPUnit_Framework_TestCase
+class UploadableFileTest extends TestCase
 {
     /**
      * @var string
@@ -22,7 +22,7 @@ class UploadableFileTest extends PHPUnit_Framework_TestCase
      */
     private $classMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata("Foo");
     }
@@ -95,7 +95,7 @@ class UploadableFileTest extends PHPUnit_Framework_TestCase
     
     public function test_it_validates_the_type()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
         
         $this->getBuilder("Foo")->build();
     }

--- a/tests/Extensions/Gedmo/UploadableTest.php
+++ b/tests/Extensions/Gedmo/UploadableTest.php
@@ -14,9 +14,9 @@ use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Builders\Field;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Uploadable;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class UploadableTest extends PHPUnit_Framework_TestCase
+class UploadableTest extends TestCase
 {
     /**
      * @var Uploadable
@@ -28,7 +28,7 @@ class UploadableTest extends PHPUnit_Framework_TestCase
      */
     private $classMetadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata(UploadableClass::class);
         $this->classMetadata->wakeupReflection(new RuntimeReflectionService());
@@ -206,35 +206,35 @@ class UploadableTest extends PHPUnit_Framework_TestCase
 
     public function test_it_shouldnt_allow_and_disallow_at_the_same_time()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
     	$this->workingBuilder()->allow('jpg')->disallow('doc')->build();
     }
 
     public function test_it_needs_a_field_set_up_as_path_or_name()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->builder->build();
     }
 
     public function test_it_validates_method_exists()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->workingBuilder()->pathMethod('nonExistent')->build();
     }
 
     public function test_it_validates_callback_exists()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->workingBuilder()->callback('nonExistent')->build();
     }
 
     public function test_it_validates_positive_sizes()
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         $this->workingBuilder()->maxSize(-1)->build();
     }
@@ -244,7 +244,7 @@ class UploadableTest extends PHPUnit_Framework_TestCase
      */
     public function test_it_validates_that_file_path_field_is_mapped_as_a_string($type)
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         Uploadable::enable();
 
@@ -259,7 +259,7 @@ class UploadableTest extends PHPUnit_Framework_TestCase
      */
     public function test_it_validates_that_file_name_field_is_mapped_as_a_string($type)
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         Uploadable::enable();
 
@@ -274,7 +274,7 @@ class UploadableTest extends PHPUnit_Framework_TestCase
      */
     public function test_it_validates_that_file_mime_type_field_is_mapped_as_a_string($type)
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         Uploadable::enable();
 
@@ -289,7 +289,7 @@ class UploadableTest extends PHPUnit_Framework_TestCase
      */
     public function test_it_validates_that_file_mime_type_field_is_mapped_as_a_decimal($type)
     {
-        $this->setExpectedException(InvalidMappingException::class);
+        $this->expectException(InvalidMappingException::class);
 
         Uploadable::enable();
 

--- a/tests/Extensions/Gedmo/VersionedTest.php
+++ b/tests/Extensions/Gedmo/VersionedTest.php
@@ -10,9 +10,9 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\Gedmo\Versioned;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
 use LaravelDoctrine\Fluent\Relations\OneToOne;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class VersionedTest extends PHPUnit_Framework_TestCase
+class VersionedTest extends TestCase
 {
     /**
      * @var Versioned
@@ -29,7 +29,7 @@ class VersionedTest extends PHPUnit_Framework_TestCase
      */
     private $fieldName;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->classMetadata = new ExtensibleClassMetadata('foo');
         $this->fieldName     = 'someField';

--- a/tests/Extensions/GedmoExtensionsTest.php
+++ b/tests/Extensions/GedmoExtensionsTest.php
@@ -17,9 +17,9 @@ use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\GedmoExtensions;
 use LaravelDoctrine\Fluent\Relations\ManyToMany;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class GedmoExtensionsTest extends PHPUnit_Framework_TestCase
+class GedmoExtensionsTest extends TestCase
 {
     /**
      * @dataProvider getClasses

--- a/tests/FluentDriverTest.php
+++ b/tests/FluentDriverTest.php
@@ -13,6 +13,7 @@ use LaravelDoctrine\Fluent\FluentDriver;
 use LaravelDoctrine\Fluent\Mappers\EmbeddableMapper;
 use LaravelDoctrine\Fluent\Mappers\EntityMapper;
 use LaravelDoctrine\Fluent\Mappers\MappedSuperClassMapper;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Embedabbles\StubEmbeddable;
 use Tests\Stubs\Entities\StubEntity;
 use Tests\Stubs\MappedSuperClasses\StubMappedSuperClass;
@@ -20,7 +21,7 @@ use Tests\Stubs\Mappings\StubEmbeddableMapping;
 use Tests\Stubs\Mappings\StubEntityMapping;
 use Tests\Stubs\Mappings\StubMappedSuperClassMapping;
 
-class FluentDriverTest extends \PHPUnit_Framework_TestCase
+class FluentDriverTest extends TestCase
 {
     public function test_it_should_load_metadata_for_entities_that_were_added_to_it()
     {
@@ -128,7 +129,8 @@ class FluentDriverTest extends \PHPUnit_Framework_TestCase
 
     public function test_the_given_mapping_class_should_exist()
     {
-        $this->setExpectedException(\InvalidArgumentException::class, 'Mapping class [Tests\DoesnExist] does not exist');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mapping class [Tests\DoesnExist] does not exist');
 
         $driver = new FluentDriver;
 
@@ -139,7 +141,8 @@ class FluentDriverTest extends \PHPUnit_Framework_TestCase
 
     public function test_the_given_mapping_class_should_implement_mapping()
     {
-        $this->setExpectedException(\InvalidArgumentException::class, 'Mapping class [Tests\Stubs\Entities\StubEntity] should implement LaravelDoctrine\Fluent\Mapping');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mapping class [Tests\Stubs\Entities\StubEntity] should implement LaravelDoctrine\Fluent\Mapping');
 
         $driver = new FluentDriver;
 
@@ -204,10 +207,8 @@ class FluentDriverTest extends \PHPUnit_Framework_TestCase
     {
         $driver = new FluentDriver();
 
-        $this->setExpectedException(
-            MappingException::class,
-            'Class [Tests\FakeEntity] does not have a mapping configuration. Make sure you create a Mapping class that extends either LaravelDoctrine\Fluent\EntityMapping, LaravelDoctrine\Fluent\EmbeddableMapping or LaravelDoctrine\Fluent\MappedSuperClassMapping. If you are using inheritance mapping, remember to create mappings for every child of the inheritance tree.'
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Class [Tests\FakeEntity] does not have a mapping configuration. Make sure you create a Mapping class that extends either LaravelDoctrine\Fluent\EntityMapping, LaravelDoctrine\Fluent\EmbeddableMapping or LaravelDoctrine\Fluent\MappedSuperClassMapping. If you are using inheritance mapping, remember to create mappings for every child of the inheritance tree.');
 
         $driver->loadMetadataForClass(
             FakeEntity::class,
@@ -223,7 +224,7 @@ class FluentDriverTest extends \PHPUnit_Framework_TestCase
             return new CustomBuilder(new ClassMetadataBuilder($metadata));
         });
 
-        $mapping = $this->getMock(EntityMapping::class);
+        $mapping = $this->createMock(EntityMapping::class);
         $mapping->expects($this->once())->method('map')->with($this->isInstanceOf(CustomBuilder::class));
 
         $driver->getMappers()->addMapper('fake', new EntityMapper($mapping));

--- a/tests/Mappers/EmbeddableMapperTest.php
+++ b/tests/Mappers/EmbeddableMapperTest.php
@@ -7,17 +7,18 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Mappers\EmbeddableMapper;
 use LaravelDoctrine\Fluent\Mappers\Mapper;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Embedabbles\StubEmbeddable;
 use Tests\Stubs\Mappings\StubEmbeddableMapping;
 
-class EmbeddableMapperTest extends \PHPUnit_Framework_TestCase
+class EmbeddableMapperTest extends TestCase
 {
     /**
      * @var EmbeddableMapper
      */
     protected $mapper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mapping      = new StubEmbeddableMapping();
         $this->mapper = new EmbeddableMapper($mapping);

--- a/tests/Mappers/EntityMapperTest.php
+++ b/tests/Mappers/EntityMapperTest.php
@@ -4,23 +4,21 @@ namespace Tests\Mappers;
 
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
-use LaravelDoctrine\Fluent\Buildable;
 use LaravelDoctrine\Fluent\Builders\Builder;
-use LaravelDoctrine\Fluent\Builders\Delay;
 use LaravelDoctrine\Fluent\Mappers\EntityMapper;
 use LaravelDoctrine\Fluent\Mappers\Mapper;
-use Mockery as m;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 use Tests\Stubs\Mappings\StubEntityMapping;
 
-class EntityMapperTest extends \PHPUnit_Framework_TestCase
+class EntityMapperTest extends TestCase
 {
     /**
      * @var EntityMapper
      */
     protected $mapper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mapping      = new StubEntityMapping;
         $this->mapper = new EntityMapper($mapping);
@@ -45,9 +43,9 @@ class EntityMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('id', $metadata->fieldNames);
         $this->assertContains('name', $metadata->fieldNames);
-        $this->assertContains(StubEntity::class, $metadata->associationMappings['parent']['targetEntity']);
-        $this->assertContains(StubEntity::class, $metadata->associationMappings['children']['targetEntity']);
-        $this->assertContains(StubEntity::class, $metadata->associationMappings['one']['targetEntity']);
-        $this->assertContains(StubEntity::class, $metadata->associationMappings['many']['targetEntity']);
+        $this->assertEquals(StubEntity::class, $metadata->associationMappings['parent']['targetEntity']);
+        $this->assertEquals(StubEntity::class, $metadata->associationMappings['children']['targetEntity']);
+        $this->assertEquals(StubEntity::class, $metadata->associationMappings['one']['targetEntity']);
+        $this->assertEquals(StubEntity::class, $metadata->associationMappings['many']['targetEntity']);
     }
 }

--- a/tests/Mappers/MappedSuperClassMapperTest.php
+++ b/tests/Mappers/MappedSuperClassMapperTest.php
@@ -7,17 +7,18 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use LaravelDoctrine\Fluent\Builders\Builder;
 use LaravelDoctrine\Fluent\Mappers\MappedSuperClassMapper;
 use LaravelDoctrine\Fluent\Mappers\Mapper;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\MappedSuperClasses\StubMappedSuperClass;
 use Tests\Stubs\Mappings\StubMappedSuperClassMapping;
 
-class MappedSuperClassMapperTest extends \PHPUnit_Framework_TestCase
+class MappedSuperClassMapperTest extends TestCase
 {
     /**
      * @var MappedSuperClassMapper
      */
     protected $mapper;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $mapping      = new StubMappedSuperClassMapping();
         $this->mapper = new MappedSuperClassMapper($mapping);

--- a/tests/Mappers/MapperSetTest.php
+++ b/tests/Mappers/MapperSetTest.php
@@ -6,19 +6,20 @@ use Doctrine\ORM\Mapping\MappingException;
 use LaravelDoctrine\Fluent\Mappers\EmbeddableMapper;
 use LaravelDoctrine\Fluent\Mappers\EntityMapper;
 use LaravelDoctrine\Fluent\Mappers\MapperSet;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Embedabbles\StubEmbeddable;
 use Tests\Stubs\Entities\StubEntity;
 use Tests\Stubs\Mappings\StubEmbeddableMapping;
 use Tests\Stubs\Mappings\StubEntityMapping;
 
-class MapperSetTest extends \PHPUnit_Framework_TestCase
+class MapperSetTest extends TestCase
 {
     /**
      * @type MapperSet
      */
     protected $mapperSet;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mapperSet = new MapperSet;
         $this->mapperSet->add(new StubEntityMapping);
@@ -35,10 +36,8 @@ class MapperSetTest extends \PHPUnit_Framework_TestCase
 
     public function test_it_should_fail_when_asked_for_an_unmapped_class()
     {
-        $this->setExpectedException(
-            MappingException::class,
-            'Class [baz] does not have a mapping configuration. Make sure you create a Mapping class that extends either LaravelDoctrine\Fluent\EntityMapping, LaravelDoctrine\Fluent\EmbeddableMapping or LaravelDoctrine\Fluent\MappedSuperClassMapping. If you are using inheritance mapping, remember to create mappings for every child of the inheritance tree.'
-        );
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Class [baz] does not have a mapping configuration. Make sure you create a Mapping class that extends either LaravelDoctrine\Fluent\EntityMapping, LaravelDoctrine\Fluent\EmbeddableMapping or LaravelDoctrine\Fluent\MappedSuperClassMapping. If you are using inheritance mapping, remember to create mappings for every child of the inheritance tree.');
 
         $this->mapperSet->getMapperFor('baz');
     }

--- a/tests/Relations/AssociationCacheTest.php
+++ b/tests/Relations/AssociationCacheTest.php
@@ -5,9 +5,10 @@ namespace Tests\Relations;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use InvalidArgumentException;
 use LaravelDoctrine\Fluent\Relations\AssociationCache;
+use PHPUnit\Framework\TestCase;
 use Tests\Stubs\Entities\StubEntity;
 
-class AssociationCacheTest extends \PHPUnit_Framework_TestCase
+class AssociationCacheTest extends TestCase
 {
     /**
      * @var string
@@ -19,7 +20,7 @@ class AssociationCacheTest extends \PHPUnit_Framework_TestCase
      */
     protected $metadata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->metadata = new ClassMetadata(StubEntity::class);
     }
@@ -50,10 +51,8 @@ class AssociationCacheTest extends \PHPUnit_Framework_TestCase
 
     public function test_cannot_set_non_existing_cache_usages()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            '[NON_EXISTING] is not a valid cache usage. Available: READ_ONLY, NONSTRICT_READ_WRITE, READ_WRITE'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('[NON_EXISTING] is not a valid cache usage. Available: READ_ONLY, NONSTRICT_READ_WRITE, READ_WRITE');
 
         $this->factory('NON_EXISTING');
     }

--- a/tests/Relations/JoinColumnTest.php
+++ b/tests/Relations/JoinColumnTest.php
@@ -4,15 +4,16 @@ namespace Tests\Relations;
 
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use LaravelDoctrine\Fluent\Relations\JoinColumn;
+use PHPUnit\Framework\TestCase;
 
-class JoinColumnTest extends \PHPUnit_Framework_TestCase
+class JoinColumnTest extends TestCase
 {
     /**
      * @var JoinColumn
      */
     protected $column;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->column = new JoinColumn(
             new DefaultNamingStrategy(),

--- a/tests/Relations/ManyToManyTest.php
+++ b/tests/Relations/ManyToManyTest.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use LaravelDoctrine\Fluent\Relations\ManyToMany;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\Builders\IsMacroable;
 use Tests\Relations\Traits\Indexable;
 use Tests\Relations\Traits\NonPrimary;
@@ -15,7 +16,7 @@ use Tests\Relations\Traits\Owning;
 
 class ManyToManyTest extends RelationTestCase
 {
-    use Indexable, Orderable, Owning, Ownable, NonPrimary, IsMacroable;
+    use Indexable, Orderable, Owning, Ownable, NonPrimary, IsMacroable, MockeryPHPUnitIntegration;
 
     /**
      * @var ManyToMany
@@ -32,7 +33,7 @@ class ManyToManyTest extends RelationTestCase
      */
     protected $field = 'children';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             FluentEntity::class

--- a/tests/Relations/ManyToOneTest.php
+++ b/tests/Relations/ManyToOneTest.php
@@ -8,13 +8,14 @@ use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use LaravelDoctrine\Fluent\Builders\Traits\Macroable;
 use LaravelDoctrine\Fluent\Relations\JoinColumn;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\Builders\IsMacroable;
 use Tests\Relations\Traits\Owning;
 use Tests\Relations\Traits\Primary;
 
 class ManyToOneTest extends RelationTestCase
 {
-    use Owning, Primary, IsMacroable;
+    use Owning, Primary, IsMacroable, MockeryPHPUnitIntegration;
 
     /**
      * @var ManyToOne
@@ -31,7 +32,7 @@ class ManyToOneTest extends RelationTestCase
      */
     protected $field = 'parent';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             FluentEntity::class

--- a/tests/Relations/OneToManyTest.php
+++ b/tests/Relations/OneToManyTest.php
@@ -32,7 +32,7 @@ class OneToManyTest extends RelationTestCase
      */
     protected $field = 'children';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             FluentEntity::class

--- a/tests/Relations/OneToOneTest.php
+++ b/tests/Relations/OneToOneTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use LaravelDoctrine\Fluent\Builders\Traits\Macroable;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
 use LaravelDoctrine\Fluent\Relations\OneToOne;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Tests\Builders\IsMacroable;
 use Tests\Relations\Traits\OneTo;
 use Tests\Relations\Traits\Ownable;
@@ -16,7 +17,7 @@ use Tests\Relations\Traits\Primary;
 
 class OneToOneTest extends RelationTestCase
 {
-    use OneTo, Owning, Ownable, Primary, IsMacroable;
+    use OneTo, Owning, Ownable, Primary, IsMacroable, MockeryPHPUnitIntegration;
 
     /**
      * @var ManyToOne
@@ -33,7 +34,7 @@ class OneToOneTest extends RelationTestCase
      */
     protected $field = 'parent';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->builder = new ClassMetadataBuilder(new ClassMetadataInfo(
             FluentEntity::class

--- a/tests/Relations/RelationTestCase.php
+++ b/tests/Relations/RelationTestCase.php
@@ -5,10 +5,9 @@ namespace Tests\Relations;
 use BadMethodCallException;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use InvalidArgumentException;
-use LaravelDoctrine\Fluent\Relations\ManyToMany;
-use LaravelDoctrine\Fluent\Relations\OneToMany;
+use PHPUnit\Framework\TestCase;
 
-class RelationTestCase extends \PHPUnit_Framework_TestCase
+class RelationTestCase extends TestCase
 {
     protected $field;
 
@@ -38,7 +37,8 @@ class RelationTestCase extends \PHPUnit_Framework_TestCase
 
     public function test_should_be_valid_cascade_action()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Cascade [invalid] does not exist');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cascade [invalid] does not exist');
 
         $this->relation->cascade(['invalid']);
     }
@@ -54,7 +54,8 @@ class RelationTestCase extends \PHPUnit_Framework_TestCase
 
     public function test_should_be_valid_fetch_action()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Fetch [invalid] does not exist');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fetch [invalid] does not exist');
 
         $this->relation->fetch('invalid');
     }
@@ -83,10 +84,8 @@ class RelationTestCase extends \PHPUnit_Framework_TestCase
 
     public function test_valid_cache_usage_should_be_given()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            '[invalid] is not a valid cache usage. Available: READ_ONLY, NONSTRICT_READ_WRITE, READ_WRITE'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('[invalid] is not a valid cache usage. Available: READ_ONLY, NONSTRICT_READ_WRITE, READ_WRITE');
 
         $this->relation->cache('invalid');
     }
@@ -113,10 +112,8 @@ class RelationTestCase extends \PHPUnit_Framework_TestCase
 
     public function test_calling_non_existing_methods_will_throw_exception()
     {
-        $this->setExpectedException(
-            BadMethodCallException::class,
-            'Relation method [doSomethingWrong] does not exist.'
-        );
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Relation method [doSomethingWrong] does not exist.');
 
         $this->relation->doSomethingWrong();
     }

--- a/tests/Relations/Traits/NonPrimary.php
+++ b/tests/Relations/Traits/NonPrimary.php
@@ -8,10 +8,8 @@ trait NonPrimary
     {
         $this->assertFalse($this->relation->getBuilder()->getClassMetadata()->isIdentifier($this->field));
 
-        $this->setExpectedException(
-            'Doctrine\ORM\Mapping\MappingException',
-            'Many-to-many or one-to-many associations are not allowed to be identifier in \'Tests\Relations\FluentEntity#' . $this->field . '\''
-        );
+        $this->expectException('Doctrine\ORM\Mapping\MappingException');
+        $this->expectExceptionMessage('Many-to-many or one-to-many associations are not allowed to be identifier in \'Tests\Relations\FluentEntity#' . $this->field . '\'');
 
         $this->relation->makePrimaryKey();
         $this->relation->build();


### PR DESCRIPTION
Looking to add PHP 8.0 support and as part of the upgrade PHPUnit/Mockery require upgrading. I changed the behaviour of one test `EntityMapperTest@test_it_should_delegate_the_proper_mapping_to_the_mapping_class` where a string comparison was actually being performed as an array comparison. Otherwise, everything else should not have changed behaviour wise.