### PR TITLE
doctrine/inflector API deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": "^7.2|^8.0",
     "doctrine/orm": "~2.6.0|~2.7.0|~2.8.0|~2.9.5",
-    "doctrine/inflector": "^1.1",
+    "doctrine/inflector": "^1.4|^2.0",
     "doctrine/persistence": "^1.3.5|^2.0"
   },
   "require-dev": {

--- a/src/Builders/Traits/Relations.php
+++ b/src/Builders/Traits/Relations.php
@@ -2,7 +2,7 @@
 
 namespace LaravelDoctrine\Fluent\Builders\Traits;
 
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use LaravelDoctrine\Fluent\Buildable;
 use LaravelDoctrine\Fluent\Relations\ManyToMany;
 use LaravelDoctrine\Fluent\Relations\ManyToOne;
@@ -128,7 +128,7 @@ trait Relations
      */
     protected function guessSingularField($entity, $field = null)
     {
-        return $field ?: Inflector::singularize(
+        return $field ?: (InflectorFactory::create()->build())->singularize(
             lcfirst(basename(str_replace('\\', '/', $entity)))
         );
     }
@@ -141,7 +141,7 @@ trait Relations
      */
     protected function guessPluralField($entity, $field = null)
     {
-        return $field ?: Inflector::pluralize($this->guessSingularField($entity));
+        return $field ?: (InflectorFactory::create()->build())->pluralize($this->guessSingularField($entity));
     }
 
     /**

--- a/src/Relations/AbstractRelation.php
+++ b/src/Relations/AbstractRelation.php
@@ -3,7 +3,7 @@
 namespace LaravelDoctrine\Fluent\Relations;
 
 use BadMethodCallException;
-use Doctrine\Common\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
 use Doctrine\ORM\Mapping\Builder\AssociationBuilder;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
 use Doctrine\ORM\Mapping\NamingStrategy;
@@ -86,7 +86,7 @@ abstract class AbstractRelation implements Relation
     public function cascade(array $cascade)
     {
         foreach ($cascade as $name) {
-            $method = 'cascade'.Inflector::classify(strtolower($name));
+            $method = 'cascade'.(InflectorFactory::create()->build())->classify(strtolower($name));
 
             if (!method_exists($this->association, $method)) {
                 throw new InvalidArgumentException('Cascade ['.$name.'] does not exist');
@@ -105,7 +105,7 @@ abstract class AbstractRelation implements Relation
      */
     public function fetch($strategy)
     {
-        $method = 'fetch'.Inflector::classify(strtolower($strategy));
+        $method = 'fetch'.(InflectorFactory::create()->build())->classify(strtolower($strategy));
 
         if (!method_exists($this->association, $method)) {
             throw new InvalidArgumentException('Fetch ['.$strategy.'] does not exist');


### PR DESCRIPTION
- Bumped up doctrine/inflector version
- Removed usage of deprecated API. Changed for the new one.