### PR TITLE
Update doctrine/persistence dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "doctrine/dbal": "^2.10|^3.3",
     "doctrine/orm": "^2.6",
     "doctrine/inflector": "^1.4|^2.0",
-    "doctrine/persistence": "^1.3.5|^2.0"
+    "doctrine/persistence": "^1.3.5|^2.0|^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~8.0|~9.0",


### PR DESCRIPTION
As mentioned in https://github.com/laravel-doctrine/fluent/issues/79 this package blocking update to Laravel 10 and laravel-doctrine/orm 2.0 versions.
Tried this on on my projects and looks like update doctrine/persistence to 3.0 not break anything for me.

