### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Doctrine ${{ matrix.doctrine }}
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2']
+        php: ['8.0', '8.1', '8.2', '8.3']
         doctrine: ['2.11', '2.12', '2.13', '2.14']
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Doctrine ${{ matrix.doctrine }}
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
         doctrine: ['2.11', '2.12', '2.13', '2.14']
     steps:
       - uses: actions/checkout@v3

--- a/src/Builders/AbstractBuilder.php
+++ b/src/Builders/AbstractBuilder.php
@@ -21,9 +21,9 @@ abstract class AbstractBuilder
 
     /**
      * @param ClassMetadataBuilder $builder
-     * @param NamingStrategy       $namingStrategy
+     * @param NamingStrategy|null  $namingStrategy
      */
-    public function __construct(ClassMetadataBuilder $builder, NamingStrategy $namingStrategy = null)
+    public function __construct(ClassMetadataBuilder $builder, ?NamingStrategy $namingStrategy = null)
     {
         $this->builder = $builder;
         $this->namingStrategy = $namingStrategy ?: new DefaultNamingStrategy();

--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -9,7 +9,7 @@ use LaravelDoctrine\Fluent\Fluent;
 use LogicException;
 
 /**
- * @method Field array($name, callable $callback = null)
+ * @method Field array($name, ?callable $callback = null)
  */
 class Builder extends AbstractBuilder implements Fluent
 {
@@ -26,7 +26,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function table($name, callable $callback = null)
+    public function table($name, ?callable $callback = null)
     {
         $this->disallowInEmbeddedClasses();
 
@@ -40,7 +40,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function entity(callable $callback = null)
+    public function entity(?callable $callback = null)
     {
         $this->disallowInEmbeddedClasses();
 
@@ -54,7 +54,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function inheritance($type, callable $callback = null)
+    public function inheritance($type, ?callable $callback = null)
     {
         $inheritance = Inheritance\InheritanceFactory::create($type, $this->builder);
 
@@ -66,7 +66,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function singleTableInheritance(callable $callback = null)
+    public function singleTableInheritance(?callable $callback = null)
     {
         return $this->inheritance(Inheritance\Inheritance::SINGLE, $callback);
     }
@@ -74,7 +74,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function joinedTableInheritance(callable $callback = null)
+    public function joinedTableInheritance(?callable $callback = null)
     {
         return $this->inheritance(Inheritance\Inheritance::JOINED, $callback);
     }
@@ -82,7 +82,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function embed($embeddable, $field = null, callable $callback = null)
+    public function embed($embeddable, $field = null, ?callable $callback = null)
     {
         $embedded = new Embedded(
             $this->builder,
@@ -116,7 +116,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function events(callable $callback = null)
+    public function events(?callable $callback = null)
     {
         $events = new LifecycleEvents($this->builder);
 
@@ -128,7 +128,7 @@ class Builder extends AbstractBuilder implements Fluent
     /**
      * {@inheritdoc}
      */
-    public function listen(callable $callback = null)
+    public function listen(?callable $callback = null)
     {
         $events = new EntityListeners($this->builder);
 
@@ -151,7 +151,7 @@ class Builder extends AbstractBuilder implements Fluent
      *
      * @return Field
      */
-    protected function setArray($name, callable $callback = null)
+    protected function setArray($name, ?callable $callback = null)
     {
         return $this->field(Types::ARRAY, $name, $callback);
     }

--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -161,7 +161,7 @@ class Field implements Buildable
      *
      * @return Field
      */
-    public function generatedValue(callable $callback = null)
+    public function generatedValue(?callable $callback = null)
     {
         $generatedValue = new GeneratedValue($this->fieldBuilder, $this->classMetadata);
 

--- a/src/Builders/Traits/Aliases.php
+++ b/src/Builders/Traits/Aliases.php
@@ -7,7 +7,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function increments($name, callable $callback = null)
+    public function increments($name, ?callable $callback = null)
     {
         $this->disallowInEmbeddedClasses();
 
@@ -17,7 +17,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function smallIncrements($name, callable $callback = null)
+    public function smallIncrements($name, ?callable $callback = null)
     {
         $this->disallowInEmbeddedClasses();
 
@@ -27,7 +27,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function bigIncrements($name, callable $callback = null)
+    public function bigIncrements($name, ?callable $callback = null)
     {
         $this->disallowInEmbeddedClasses();
 
@@ -37,7 +37,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function unsignedSmallInteger($name, callable $callback = null)
+    public function unsignedSmallInteger($name, ?callable $callback = null)
     {
         return $this->smallInteger($name, $callback)->unsigned();
     }
@@ -45,7 +45,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function unsignedInteger($name, callable $callback = null)
+    public function unsignedInteger($name, ?callable $callback = null)
     {
         return $this->integer($name, $callback)->unsigned();
     }
@@ -53,7 +53,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function unsignedBigInteger($name, callable $callback = null)
+    public function unsignedBigInteger($name, ?callable $callback = null)
     {
         return $this->bigInteger($name, $callback)->unsigned();
     }
@@ -61,7 +61,7 @@ trait Aliases
     /**
      * {@inheritdoc}
      */
-    public function rememberToken($name = 'rememberToken', callable $callback = null)
+    public function rememberToken($name = 'rememberToken', ?callable $callback = null)
     {
         return $this->string($name, $callback)->nullable()->length(100);
     }
@@ -79,7 +79,7 @@ trait Aliases
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
-    abstract public function integer($name, callable $callback = null);
+    abstract public function integer($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -87,7 +87,7 @@ trait Aliases
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
-    abstract public function smallInteger($name, callable $callback = null);
+    abstract public function smallInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -95,7 +95,7 @@ trait Aliases
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
-    abstract public function bigInteger($name, callable $callback = null);
+    abstract public function bigInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -103,5 +103,5 @@ trait Aliases
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
-    abstract public function string($name, callable $callback = null);
+    abstract public function string($name, ?callable $callback = null);
 }

--- a/src/Builders/Traits/Dates.php
+++ b/src/Builders/Traits/Dates.php
@@ -9,7 +9,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function date($name, callable $callback = null)
+    public function date($name, ?callable $callback = null)
     {
         return $this->field(Types::DATE_MUTABLE, $name, $callback);
     }
@@ -17,7 +17,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function dateTime($name, callable $callback = null)
+    public function dateTime($name, ?callable $callback = null)
     {
         return $this->field(Types::DATETIME_MUTABLE, $name, $callback);
     }
@@ -25,7 +25,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function dateTimeTz($name, callable $callback = null)
+    public function dateTimeTz($name, ?callable $callback = null)
     {
         return $this->field(Types::DATETIMETZ_MUTABLE, $name, $callback);
     }
@@ -33,7 +33,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function time($name, callable $callback = null)
+    public function time($name, ?callable $callback = null)
     {
         return $this->field(Types::TIME_MUTABLE, $name, $callback);
     }
@@ -41,7 +41,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function carbonDateTime($name, callable $callback = null)
+    public function carbonDateTime($name, ?callable $callback = null)
     {
         return $this->field('carbondatetime', $name, $callback);
     }
@@ -49,7 +49,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function carbonDateTimeTz($name, callable $callback = null)
+    public function carbonDateTimeTz($name, ?callable $callback = null)
     {
         return $this->field('carbondatetimetz', $name, $callback);
     }
@@ -57,7 +57,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function carbonDate($name, callable $callback = null)
+    public function carbonDate($name, ?callable $callback = null)
     {
         return $this->field('carbondate', $name, $callback);
     }
@@ -65,7 +65,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function carbonTime($name, callable $callback = null)
+    public function carbonTime($name, ?callable $callback = null)
     {
         return $this->field('carbontime', $name, $callback);
     }
@@ -73,7 +73,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function zendDate($name, callable $callback = null)
+    public function zendDate($name, ?callable $callback = null)
     {
         return $this->field('zenddate', $name, $callback);
     }
@@ -81,7 +81,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function timestamp($name, callable $callback = null)
+    public function timestamp($name, ?callable $callback = null)
     {
         return $this->carbonDateTime($name, $callback);
     }
@@ -89,7 +89,7 @@ trait Dates
     /**
      * {@inheritdoc}
      */
-    public function timestampTz($name, callable $callback = null)
+    public function timestampTz($name, ?callable $callback = null)
     {
         return $this->carbonDateTimeTz($name, $callback);
     }
@@ -101,5 +101,5 @@ trait Dates
      *
      * @return \LaravelDoctrine\Fluent\Builders\Field
      */
-    abstract public function field($type, $name, callable $callback = null);
+    abstract public function field($type, $name, ?callable $callback = null);
 }

--- a/src/Builders/Traits/Fields.php
+++ b/src/Builders/Traits/Fields.php
@@ -11,7 +11,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function field($type, $name, callable $callback = null)
+    public function field($type, $name, ?callable $callback = null)
     {
         $field = Field::make($this->getBuilder(), $type, $name);
 
@@ -23,7 +23,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function string($name, callable $callback = null)
+    public function string($name, ?callable $callback = null)
     {
         return $this->field(Types::STRING, $name, $callback);
     }
@@ -31,7 +31,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function text($name, callable $callback = null)
+    public function text($name, ?callable $callback = null)
     {
         return $this->field(Types::TEXT, $name, $callback);
     }
@@ -39,7 +39,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function integer($name, callable $callback = null)
+    public function integer($name, ?callable $callback = null)
     {
         return $this->field(Types::INTEGER, $name, $callback);
     }
@@ -47,7 +47,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function smallInteger($name, callable $callback = null)
+    public function smallInteger($name, ?callable $callback = null)
     {
         return $this->field(Types::SMALLINT, $name, $callback);
     }
@@ -55,7 +55,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function bigInteger($name, callable $callback = null)
+    public function bigInteger($name, ?callable $callback = null)
     {
         return $this->field(Types::BIGINT, $name, $callback);
     }
@@ -63,7 +63,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function guid($name, callable $callback = null)
+    public function guid($name, ?callable $callback = null)
     {
         return $this->field(Types::GUID, $name, $callback);
     }
@@ -71,7 +71,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function blob($name, callable $callback = null)
+    public function blob($name, ?callable $callback = null)
     {
         return $this->field(Types::BLOB, $name, $callback);
     }
@@ -79,7 +79,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function object($name, callable $callback = null)
+    public function object($name, ?callable $callback = null)
     {
         return $this->field(Types::OBJECT, $name, $callback);
     }
@@ -87,7 +87,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function float($name, callable $callback = null)
+    public function float($name, ?callable $callback = null)
     {
         return $this->field(Types::FLOAT, $name, $callback)->precision(8)->scale(2);
     }
@@ -95,7 +95,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function decimal($name, callable $callback = null)
+    public function decimal($name, ?callable $callback = null)
     {
         return $this->field(Types::DECIMAL, $name, $callback)->precision(8)->scale(2);
     }
@@ -103,7 +103,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function boolean($name, callable $callback = null)
+    public function boolean($name, ?callable $callback = null)
     {
         return $this->field(Types::BOOLEAN, $name, $callback);
     }
@@ -111,7 +111,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function simpleArray($name, callable $callback = null)
+    public function simpleArray($name, ?callable $callback = null)
     {
         return $this->field(Types::SIMPLE_ARRAY, $name, $callback);
     }
@@ -119,7 +119,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function jsonArray($name, callable $callback = null)
+    public function jsonArray($name, ?callable $callback = null)
     {
         return $this->field(Types::JSON, $name, $callback);
     }
@@ -127,7 +127,7 @@ trait Fields
     /**
      * {@inheritdoc}
      */
-    public function binary($name, callable $callback = null)
+    public function binary($name, ?callable $callback = null)
     {
         return $this->field(Types::BINARY, $name, $callback)->nullable();
     }
@@ -141,5 +141,5 @@ trait Fields
      * @param Buildable     $buildable
      * @param callable|null $callback
      */
-    abstract protected function callbackAndQueue(Buildable $buildable, callable $callback = null);
+    abstract protected function callbackAndQueue(Buildable $buildable, ?callable $callback = null);
 }

--- a/src/Builders/Traits/Macroable.php
+++ b/src/Builders/Traits/Macroable.php
@@ -15,7 +15,7 @@ trait Macroable
      * @param string        $method
      * @param callable|null $callback
      */
-    public static function macro($method, callable $callback = null)
+    public static function macro($method, ?callable $callback = null)
     {
         if (!is_callable($callback)) {
             throw new InvalidArgumentException('Macros should be used with a closure argument, none given');

--- a/src/Builders/Traits/Queueable.php
+++ b/src/Builders/Traits/Queueable.php
@@ -24,7 +24,7 @@ trait Queueable
      * @param Buildable     $buildable
      * @param callable|null $callback
      */
-    public function callbackAndQueue(Buildable $buildable, callable $callback = null)
+    public function callbackAndQueue(Buildable $buildable, ?callable $callback = null)
     {
         $this->callIfCallable($callback, $buildable);
 

--- a/src/Builders/Traits/Relations.php
+++ b/src/Builders/Traits/Relations.php
@@ -15,7 +15,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function hasOne($entity, $field = null, callable $callback = null)
+    public function hasOne($entity, $field = null, ?callable $callback = null)
     {
         return $this->oneToOne($entity, $field, $callback)->ownedBy(
             $this->guessSingularField($entity)
@@ -25,7 +25,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function oneToOne($entity, $field = null, callable $callback = null)
+    public function oneToOne($entity, $field = null, ?callable $callback = null)
     {
         return $this->addRelation(
             new OneToOne(
@@ -41,7 +41,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function belongsTo($entity, $field = null, callable $callback = null)
+    public function belongsTo($entity, $field = null, ?callable $callback = null)
     {
         return $this->manyToOne($entity, $field, $callback);
     }
@@ -49,7 +49,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function manyToOne($entity, $field = null, callable $callback = null)
+    public function manyToOne($entity, $field = null, ?callable $callback = null)
     {
         return $this->addRelation(
             new ManyToOne(
@@ -65,7 +65,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function hasMany($entity, $field = null, callable $callback = null)
+    public function hasMany($entity, $field = null, ?callable $callback = null)
     {
         return $this->oneToMany($entity, $field, $callback);
     }
@@ -73,7 +73,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function oneToMany($entity, $field = null, callable $callback = null)
+    public function oneToMany($entity, $field = null, ?callable $callback = null)
     {
         return $this->addRelation(
             new OneToMany(
@@ -89,7 +89,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function belongsToMany($entity, $field = null, callable $callback = null)
+    public function belongsToMany($entity, $field = null, ?callable $callback = null)
     {
         return $this->manyToMany($entity, $field, $callback);
     }
@@ -97,7 +97,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function manyToMany($entity, $field = null, callable $callback = null)
+    public function manyToMany($entity, $field = null, ?callable $callback = null)
     {
         return $this->addRelation(
             new ManyToMany(
@@ -113,7 +113,7 @@ trait Relations
     /**
      * {@inheritdoc}
      */
-    public function addRelation(Relation $relation, callable $callback = null)
+    public function addRelation(Relation $relation, ?callable $callback = null)
     {
         $this->callbackAndQueue($relation, $callback);
 
@@ -153,7 +153,7 @@ trait Relations
      * @param Buildable     $buildable
      * @param callable|null $callback
      */
-    abstract protected function callbackAndQueue(Buildable $buildable, callable $callback = null);
+    abstract protected function callbackAndQueue(Buildable $buildable, ?callable $callback = null);
 
     /**
      * @return \Doctrine\ORM\Mapping\NamingStrategy

--- a/src/Extensions/Gedmo/GedmoFieldHints.php
+++ b/src/Extensions/Gedmo/GedmoFieldHints.php
@@ -16,7 +16,7 @@ namespace LaravelDoctrine\Fluent\Extensions\Gedmo;
  * @method void           treeLeft()
  * @method void           treeLevel()
  * @method void           treeParent()
- * @method TreePath       treePath($separator = '|', callable $callback = null)
+ * @method TreePath       treePath($separator = '|', ?callable $callback = null)
  * @method void           treePathHash()
  * @method void           treePathSource()
  * @method void           treeRight()

--- a/src/Extensions/Gedmo/MaterializedPath.php
+++ b/src/Extensions/Gedmo/MaterializedPath.php
@@ -67,7 +67,7 @@ class MaterializedPath extends TreeStrategy implements Buildable, Extension, Del
      *
      * @return $this
      */
-    public function path($field = 'path', $separator = '|', callable $callback = null)
+    public function path($field = 'path', $separator = '|', ?callable $callback = null)
     {
         $this->mapField('string', $field, null, true);
 

--- a/src/Extensions/Gedmo/NestedSet.php
+++ b/src/Extensions/Gedmo/NestedSet.php
@@ -45,7 +45,7 @@ class NestedSet extends TreeStrategy implements Buildable, Extension, Delay
      *
      * @return $this
      */
-    public function left($field = 'left', $type = 'integer', callable $callback = null)
+    public function left($field = 'left', $type = 'integer', ?callable $callback = null)
     {
         $this->validateNumericField($type, $field);
 
@@ -65,7 +65,7 @@ class NestedSet extends TreeStrategy implements Buildable, Extension, Delay
      *
      * @return $this
      */
-    public function right($field = 'right', $type = 'integer', callable $callback = null)
+    public function right($field = 'right', $type = 'integer', ?callable $callback = null)
     {
         $this->validateNumericField($type, $field);
 
@@ -82,7 +82,7 @@ class NestedSet extends TreeStrategy implements Buildable, Extension, Delay
      *
      * @return $this
      */
-    public function root($field = 'root', callable $callback = null)
+    public function root($field = 'root', ?callable $callback = null)
     {
         $this->addSelfReferencingRelation($field, $callback);
 

--- a/src/Extensions/Gedmo/Tree.php
+++ b/src/Extensions/Gedmo/Tree.php
@@ -34,7 +34,7 @@ class Tree implements Buildable, Extension
      */
     public static function enable()
     {
-        Builder::macro(self::MACRO_METHOD, function (Fluent $builder, callable $callback = null) {
+        Builder::macro(self::MACRO_METHOD, function (Fluent $builder, ?callable $callback = null) {
             $tree = new static($builder);
 
             if (is_callable($callback)) {

--- a/src/Extensions/Gedmo/TreeStrategy.php
+++ b/src/Extensions/Gedmo/TreeStrategy.php
@@ -52,7 +52,7 @@ abstract class TreeStrategy implements Buildable, Extension
      *
      * @return $this
      */
-    public function level($field = 'level', $type = 'integer', callable $callback = null)
+    public function level($field = 'level', $type = 'integer', ?callable $callback = null)
     {
         $this->validateNumericField($type, $field);
 
@@ -69,7 +69,7 @@ abstract class TreeStrategy implements Buildable, Extension
      *
      * @return $this
      */
-    public function parent($field = 'parent', callable $callback = null)
+    public function parent($field = 'parent', ?callable $callback = null)
     {
         $this->addSelfReferencingRelation($field, $callback);
 
@@ -104,7 +104,7 @@ abstract class TreeStrategy implements Buildable, Extension
      * @param callable|null $callback
      * @param bool|false    $nullable
      */
-    protected function mapField($type, $field, callable $callback = null, $nullable = false)
+    protected function mapField($type, $field, ?callable $callback = null, $nullable = false)
     {
         $this->builder->field($type, $field, $callback)->nullable($nullable);
     }
@@ -136,7 +136,7 @@ abstract class TreeStrategy implements Buildable, Extension
      * @param string        $field
      * @param callable|null $callback
      */
-    protected function addSelfReferencingRelation($field, callable $callback = null)
+    protected function addSelfReferencingRelation($field, ?callable $callback = null)
     {
         $this->builder->belongsTo($this->myself(), $field, $callback)->nullable();
     }

--- a/src/Fluent.php
+++ b/src/Fluent.php
@@ -3,14 +3,14 @@
 namespace LaravelDoctrine\Fluent;
 
 /**
- * @method Builders\Field array($name, callable $callback = null)
+ * @method Builders\Field array($name, ?callable $callback = null)
  *
  * Extensions:
  * @method void                              loggable(string $logEntry = null)
  * @method Extensions\Gedmo\SoftDeleteable   softDelete(string $fieldName = 'deletedAt', string $type = 'dateTime')
  * @method void                              timestamps(string $createdAt = 'createdAt', string $updatedAt = 'updatedAt', string $type = 'dateTime')
  * @method Extensions\Gedmo\TranslationClass translationClass(string $class)
- * @method Extensions\Gedmo\Tree             tree(callable $callback = null)
+ * @method Extensions\Gedmo\Tree             tree(?callable $callback = null)
  * @method Extensions\Gedmo\Uploadable       uploadable()
  * @method                                   locale(string $fieldName)
  */
@@ -22,14 +22,14 @@ interface Fluent extends Buildable
      *
      * @return Builders\Table
      */
-    public function table($name, callable $callback = null);
+    public function table($name, ?callable $callback = null);
 
     /**
      * @param callable|null $callback
      *
      * @return Builders\Entity
      */
-    public function entity(callable $callback = null);
+    public function entity(?callable $callback = null);
 
     /**
      * @param array|string $columns
@@ -52,7 +52,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function field($type, $name, callable $callback = null);
+    public function field($type, $name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -60,7 +60,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function increments($name, callable $callback = null);
+    public function increments($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -68,7 +68,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function smallIncrements($name, callable $callback = null);
+    public function smallIncrements($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -76,7 +76,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function bigIncrements($name, callable $callback = null);
+    public function bigIncrements($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -84,7 +84,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function string($name, callable $callback = null);
+    public function string($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -92,7 +92,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function text($name, callable $callback = null);
+    public function text($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -100,7 +100,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function integer($name, callable $callback = null);
+    public function integer($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -108,7 +108,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function smallInteger($name, callable $callback = null);
+    public function smallInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -116,7 +116,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function bigInteger($name, callable $callback = null);
+    public function bigInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -124,7 +124,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function unsignedSmallInteger($name, callable $callback = null);
+    public function unsignedSmallInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -132,7 +132,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function unsignedInteger($name, callable $callback = null);
+    public function unsignedInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -140,7 +140,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function unsignedBigInteger($name, callable $callback = null);
+    public function unsignedBigInteger($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -148,7 +148,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function float($name, callable $callback = null);
+    public function float($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -156,7 +156,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function decimal($name, callable $callback = null);
+    public function decimal($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -164,7 +164,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function boolean($name, callable $callback = null);
+    public function boolean($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -172,7 +172,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function jsonArray($name, callable $callback = null);
+    public function jsonArray($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -180,7 +180,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function date($name, callable $callback = null);
+    public function date($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -188,7 +188,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function dateTime($name, callable $callback = null);
+    public function dateTime($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -196,7 +196,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function dateTimeTz($name, callable $callback = null);
+    public function dateTimeTz($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -204,7 +204,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function time($name, callable $callback = null);
+    public function time($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -212,7 +212,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function carbonDateTime($name, callable $callback = null);
+    public function carbonDateTime($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -220,7 +220,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function carbonDateTimeTz($name, callable $callback = null);
+    public function carbonDateTimeTz($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -228,7 +228,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function carbonDate($name, callable $callback = null);
+    public function carbonDate($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -236,7 +236,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function carbonTime($name, callable $callback = null);
+    public function carbonTime($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -244,7 +244,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function zendDate($name, callable $callback = null);
+    public function zendDate($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -252,7 +252,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function timestamp($name, callable $callback = null);
+    public function timestamp($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -260,7 +260,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function timestampTz($name, callable $callback = null);
+    public function timestampTz($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -268,7 +268,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function binary($name, callable $callback = null);
+    public function binary($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -276,7 +276,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function rememberToken($name = 'rememberToken', callable $callback = null);
+    public function rememberToken($name = 'rememberToken', ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -285,7 +285,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\OneToOne
      */
-    public function hasOne($entity, $field = null, callable $callback = null);
+    public function hasOne($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -294,7 +294,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\OneToOne
      */
-    public function oneToOne($entity, $field = null, callable $callback = null);
+    public function oneToOne($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -303,7 +303,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\ManyToOne
      */
-    public function belongsTo($entity, $field = null, callable $callback = null);
+    public function belongsTo($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -312,7 +312,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\ManyToOne
      */
-    public function manyToOne($entity, $field = null, callable $callback = null);
+    public function manyToOne($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -321,7 +321,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\OneToMany
      */
-    public function hasMany($entity, $field = null, callable $callback = null);
+    public function hasMany($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -330,7 +330,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\OneToMany
      */
-    public function oneToMany($entity, $field = null, callable $callback = null);
+    public function oneToMany($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -339,7 +339,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\ManyToMany
      */
-    public function belongsToMany($entity, $field = null, callable $callback = null);
+    public function belongsToMany($entity, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $entity
@@ -348,7 +348,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\ManyToMany
      */
-    public function manyToMany($entity, $field, callable $callback = null);
+    public function manyToMany($entity, $field, ?callable $callback = null);
 
     /**
      * Adds a custom relation to the entity.
@@ -358,7 +358,7 @@ interface Fluent extends Buildable
      *
      * @return Relations\Relation
      */
-    public function addRelation(Relations\Relation $relation, callable $callback = null);
+    public function addRelation(Relations\Relation $relation, ?callable $callback = null);
 
     /**
      * @return bool
@@ -374,7 +374,7 @@ interface Fluent extends Buildable
      * @param string        $method
      * @param callable|null $callback
      */
-    public static function macro($method, callable $callback = null);
+    public static function macro($method, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -382,7 +382,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function guid($name, callable $callback = null);
+    public function guid($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -390,7 +390,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function blob($name, callable $callback = null);
+    public function blob($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -398,7 +398,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function object($name, callable $callback = null);
+    public function object($name, ?callable $callback = null);
 
     /**
      * @param string        $name
@@ -406,7 +406,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Field
      */
-    public function simpleArray($name, callable $callback = null);
+    public function simpleArray($name, ?callable $callback = null);
 
     /**
      * @param string        $embeddable
@@ -415,7 +415,7 @@ interface Fluent extends Buildable
      *
      * @return Builders\Embedded
      */
-    public function embed($embeddable, $field = null, callable $callback = null);
+    public function embed($embeddable, $field = null, ?callable $callback = null);
 
     /**
      * @param string        $type
@@ -423,21 +423,21 @@ interface Fluent extends Buildable
      *
      * @return Builders\Inheritance\Inheritance
      */
-    public function inheritance($type, callable $callback = null);
+    public function inheritance($type, ?callable $callback = null);
 
     /**
      * @param callable|null $callback
      *
      * @return Builders\Inheritance\Inheritance
      */
-    public function singleTableInheritance(callable $callback = null);
+    public function singleTableInheritance(?callable $callback = null);
 
     /**
      * @param callable|null $callback
      *
      * @return Builders\Inheritance\Inheritance
      */
-    public function joinedTableInheritance(callable $callback = null);
+    public function joinedTableInheritance(?callable $callback = null);
 
     /**
      * @param array|string $fields
@@ -459,12 +459,12 @@ interface Fluent extends Buildable
      *
      * @return Builders\LifecycleEvents
      */
-    public function events(callable $callback = null);
+    public function events(?callable $callback = null);
 
     /**
      * @param callable|null $callback
      *
      * @return Builders\EntityListeners
      */
-    public function listen(callable $callback = null);
+    public function listen(?callable $callback = null);
 }

--- a/src/FluentDriver.php
+++ b/src/FluentDriver.php
@@ -32,7 +32,7 @@ class FluentDriver implements MappingDriver
      */
     public function __construct(
         array $mappings = [],
-        NamingStrategy $namingStrategy = null
+        ?NamingStrategy $namingStrategy = null
     ) {
         $this->fluentFactory = function (ClassMetadata $metadata) use ($namingStrategy) {
             return new Builder(new ClassMetadataBuilder($metadata), $namingStrategy);

--- a/src/Relations/ManyToOne.php
+++ b/src/Relations/ManyToOne.php
@@ -66,7 +66,7 @@ class ManyToOne extends AbstractRelation
      *
      * @return JoinColumn|false
      */
-    public function getJoinColumn(callable $callback = null)
+    public function getJoinColumn(?callable $callback = null)
     {
         $joinColumn = reset($this->joinColumns);
 


### PR DESCRIPTION
This pull request adds support for PHP 8.4 by updating the CI workflow and ensuring compatibility.

Deprecation notices were appearing under PHP 8.4, such as:

```
Deprecated: LaravelDoctrine\Fluent\Fluent::hasMany(): Implicitly marking parameter $callback as nullable is deprecated
```