### PR TITLE
Fix ManyToMany override for Doctrine ORM 3.1 and add DBAL 4 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,11 +11,43 @@ on:
 jobs:
   tests:
     runs-on: 'ubuntu-latest'
-    name: PHP ${{ matrix.php }} - Doctrine ${{ matrix.doctrine }}
+    name: PHP ${{ matrix.php }} - ORM ${{ matrix.orm }} - DBAL ${{ matrix.dbal }}
     strategy:
       matrix:
         php: ['8.1', '8.2', '8.3', '8.4']
-        doctrine: ['3.1', '3.2', '3.3', '3.4', '3.5']
+        orm: ['3.1', '^3']
+        dbal: ['3.8.2', '^3', '^4']
+        exclude:
+          # ---- Keep ORM 3.1 + DBAL * combos only on PHP 8.1
+          - php: '8.2'
+            orm: '3.1'
+            dbal: '3.8'
+          - php: '8.3'
+            orm: '3.1'
+            dbal: '3.8'
+          - php: '8.4'
+            orm: '3.1'
+            dbal: '3.8'
+
+          - php: '8.2'
+            orm: '3.1'
+            dbal: '^3'
+          - php: '8.3'
+            orm: '3.1'
+            dbal: '^3'
+          - php: '8.4'
+            orm: '3.1'
+            dbal: '^3'
+
+          - php: '8.2'
+            orm: '3.1'
+            dbal: '^4'
+          - php: '8.3'
+            orm: '3.1'
+            dbal: '^4'
+          - php: '8.4'
+            orm: '3.1'
+            dbal: '^4'
     steps:
       - uses: actions/checkout@v5
       - name: Setup PHP
@@ -27,8 +59,8 @@ jobs:
       - name: Install Composer dependencies
         run: rm -f composer.lock
 
-      - name: Install doctrine/orm ${{ matrix.doctrine }}
-        run: composer require --no-progress --no-scripts --no-plugins doctrine/orm "~${{ matrix.doctrine }}.0" -v
+      - name: Install doctrine/orm ${{ matrix.orm }} and doctrine/dbal ${{ matrix.dbal }}
+        run: composer require --no-progress --no-scripts --no-plugins "doctrine/orm:${{ matrix.orm }}" "doctrine/dbal:${{ matrix.dbal }}" -v
 
       - name: Update dependencies
         run: composer update --no-interaction

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .php_cs.cache
 .phpunit.result.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "doctrine/dbal": "^2.10|^3.3",
+    "doctrine/dbal": "^3.8.2|^4",
     "doctrine/orm": "^3.1",
     "doctrine/inflector": "^1.4|^2.0",
     "doctrine/persistence": "^1.3.5|^2.0|^3.0"
@@ -34,7 +34,8 @@
     "mockery/mockery": "~1.0",
     "beberlei/doctrineextensions": "~1.0",
     "zf1/zend-date": "~1.12",
-    "nesbot/carbon": "*",
+    "nesbot/carbon": "^2.0|^3.0",
+    "carbonphp/carbon-doctrine-types": "^2.1|^3.0",
     "gedmo/doctrine-extensions": "^2.4|^3"
   },
   "autoload": {

--- a/src/Builders/Builder.php
+++ b/src/Builders/Builder.php
@@ -153,7 +153,7 @@ class Builder extends AbstractBuilder implements Fluent
      */
     protected function setArray($name, ?callable $callback = null)
     {
-        return $this->field(Types::ARRAY, $name, $callback);
+        return $this->field(Types::JSON, $name, $callback);
     }
 
     /**

--- a/src/Builders/Field.php
+++ b/src/Builders/Field.php
@@ -101,7 +101,7 @@ class Field implements Buildable
     {
         $type = Type::getType($type);
 
-        $field = $builder->createField($name, $type->getName());
+        $field = $builder->createField($name, Type::lookupName($type));
 
         return new static($field, $builder, $type, $name);
     }

--- a/src/Builders/Overrides/AssociationOverride.php
+++ b/src/Builders/Overrides/AssociationOverride.php
@@ -169,53 +169,53 @@ class AssociationOverride implements Buildable
         );
     }
 
-    /**
-     * @param array $target
-     * @param array $source
-     *
-     * @return array
-     */
     protected function mapJoinTable(array $target = [], array $source = [])
     {
-        $joinTable['name'] = $target['name'];
+        $joinTable = [];
+
+        $joinTable['name'] = $target['name'] ?? $source['name'];
 
         if ($this->hasJoinColumns($target)) {
             $joinTable['joinColumns'] = $this->mapJoinColumns(
                 $target['joinColumns'],
-                $source['joinColumns']
+                $source['joinColumns'] ?? []
             );
         }
 
         if ($this->hasInverseJoinColumns($target)) {
             $joinTable['inverseJoinColumns'] = $this->mapJoinColumns(
                 $target['inverseJoinColumns'],
-                $source['inverseJoinColumns']
+                $source['inverseJoinColumns'] ?? []
             );
         }
 
         return $joinTable;
     }
 
-    /**
-     * @param array $target
-     * @param array $source
-     *
-     * @return mixed
-     *
-     * @internal param $target
-     * @internal param $source
-     * @internal param $overrideMapping
-     */
     protected function mapJoinColumns(array $target = [], array $source = [])
     {
         $joinColumns = [];
-        foreach ($target as $index => $joinColumn) {
-            if (isset($source[$index])) {
-                $diff = array_diff((array) $joinColumn, (array) $source[$index]);
 
-                if (!empty($diff)) {
-                    $joinColumns[] = $diff;
+        foreach ($target as $index => $joinColumn) {
+            if (!isset($source[$index])) {
+                continue;
+            }
+
+            $joinColumn = (array) $joinColumn;
+            $sourceCol = (array) $source[$index];
+
+            $diff = array_diff_assoc($joinColumn, $sourceCol);
+
+            if ($diff !== []) {
+                // Doctrine ORM 3.1 needs referencedColumnName present
+                if (isset($diff['name']) && !isset($diff['referencedColumnName'])) {
+                    $diff['referencedColumnName'] =
+                        $joinColumn['referencedColumnName']
+                        ?? $sourceCol['referencedColumnName']
+                        ?? 'id';
                 }
+
+                $joinColumns[] = $diff;
             }
         }
 

--- a/src/Builders/Traits/Fields.php
+++ b/src/Builders/Traits/Fields.php
@@ -81,7 +81,7 @@ trait Fields
      */
     public function object($name, ?callable $callback = null)
     {
-        return $this->field(Types::OBJECT, $name, $callback);
+        return $this->field(Types::JSON, $name, $callback);
     }
 
     /**

--- a/tests/Builders/BuilderTest.php
+++ b/tests/Builders/BuilderTest.php
@@ -65,7 +65,7 @@ class BuilderTest extends TestCase
         'bigInteger'       => Types::BIGINT,
         'float'            => Types::FLOAT,
         'decimal'          => Types::DECIMAL,
-        'object'           => Types::OBJECT,
+        'object'           => Types::JSON,
         'boolean'          => Types::BOOLEAN,
         'jsonArray'        => Types::JSON,
         'date'             => Types::DATE_MUTABLE,
@@ -82,7 +82,7 @@ class BuilderTest extends TestCase
         'binary'           => Types::BINARY,
         'guid'             => Types::GUID,
         'blob'             => Types::BLOB,
-        'array'            => Types::ARRAY,
+        'array'            => Types::JSON,
         'simpleArray'      => Types::SIMPLE_ARRAY,
     ];
 

--- a/tests/Builders/FieldTest.php
+++ b/tests/Builders/FieldTest.php
@@ -244,7 +244,7 @@ class FieldTest extends TestCase
 
     public function test_array_cannot_be_used_for_versioning()
     {
-        $this->doTestInvalidTypeForVersioning('array');
+        $this->doTestInvalidTypeForVersioning('json');
     }
 
     public function test_simple_array_cannot_be_used_for_versioning()
@@ -284,7 +284,7 @@ class FieldTest extends TestCase
 
     public function test_object_cannot_be_used_for_versioning()
     {
-        $this->doTestInvalidTypeForVersioning('object');
+        $this->doTestInvalidTypeForVersioning('json');
     }
 
     public function test_string_cannot_be_used_for_versioning()

--- a/tests/Extensions/ExtensibleClassMetadataFactoryFactoryTest.php
+++ b/tests/Extensions/ExtensibleClassMetadataFactoryFactoryTest.php
@@ -4,7 +4,6 @@ namespace Tests\Extensions;
 
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadata;
 use LaravelDoctrine\Fluent\Extensions\ExtensibleClassMetadataFactory;
@@ -21,9 +20,9 @@ class ExtensibleClassMetadataFactoryFactoryTest extends TestCase
         $config = \Mockery::mock(Configuration::class);
         $namingStrategy = \Mockery::mock(NamingStrategy::class);
 
-        $em->shouldReceive('getConfiguration')->twice()->andReturn($config);
+        $em->shouldReceive('getConfiguration')->atLeast()->once()->andReturn($config);
         $config->shouldReceive('getNamingStrategy')->once()->andReturn($namingStrategy);
-        $config->shouldReceive('isNativeLazyObjectsEnabled')->once()->andReturn(false);
+        $config->shouldReceive('isNativeLazyObjectsEnabled')->zeroOrMoreTimes()->andReturn(false);
 
         $factory = new ExtensionFactoryTest();
         $factory->setEntityManager($em);


### PR DESCRIPTION
This PR fixes a bug in `ManyToMany` association overrides that appears when using Doctrine ORM 3.1.

When renaming the join column via:
```
$relation->joinTable('custom_table')->source('source_id');
```

Fluent could generate an incomplete mapping missing `referencedColumnName`, which causes Doctrine ORM 3.1 to fail during metadata normalization.

The override logic now keeps required join column information intact, making it work correctly on ORM 3.1 and newer versions.

While working on this, I also added a few changes needed for Doctrine DBAL 4 compatibility.